### PR TITLE
fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Methods:
 - Auth: `login()`, `register()`
 - Goals: `get_goals()`, `create_goal()`, `update_goal()`, `delete_goal()`
 - Journal: `get_journal_entries()`, `get_journal_by_date(date_str)`, `create_journal_entry(date_str, content)`, `update_journal_entry(entry_id, content)`
-- Analysis: `generate_analysis(week_start_date)`, `get_latest_analysis()`
+- Analysis: `generate_analysis(week_start_date)`, `get_latest_analysis()`, `get_analysis_list()`, `delete_analysis(id)`
 
 **Backend URL**: Set `APIClient.API_BASE_URL` in `services/api_client.py`. For phone testing, use your computer's local IP instead of localhost.
 
@@ -81,7 +81,8 @@ Always check `../coach-assistant-backend/api/views.py` before implementing new A
 | Goals | `GET/POST /api/goals/`, `PATCH /api/goals/{id}/` | |
 | Analysis generate | `POST /api/analysis/generate/` | Body: `{week_start_date, provider}` (provider optional, default `"openai"`) |
 | Analysis latest | `GET /api/analysis/latest/` | Query: `?provider=openai\|anthropic\|local` (optional) |
-| Analysis list | `GET /api/analysis/` | Returns all analyses (pending backend #42) |
+| Analysis list | `GET /api/analysis/` | Returns all analyses for the user |
+| Analysis delete | `DELETE /api/analysis/{id}/` | |
 
 ## Screen Layout Pattern
 
@@ -126,13 +127,13 @@ BG = (0.96, 0.96, 0.96, 1)
 | #8 | Implement Journal API Integration | ✅ Done |
 | #9 | Implement Weekly Analysis Screen UI | ✅ Done |
 | #10 | Implement Analysis API Integration | ✅ Done |
-| #15 | Setup Buildozer for Android Build | 🔲 Pending |
-| #16 | Test on Android Device | 🔲 Pending |
+| #15 | Setup Buildozer for Android Build | ✅ Done |
+| #16 | Test on Android Device | ✅ Done |
 | #21 | Multi-Provider Support in API Client | 🔲 Pending |
 | #22 | Provider Selector UI on Analysis Screen | 🔲 Pending |
 | #23 | Compare Analyses from Multiple Providers | 🔲 Pending |
 
-**Milestone "POC Ready"** = Issues #1–10, then #15–16 to get on phone.
+**Milestone "POC Ready"** = Issues #1–10, #15–16 ✅ Complete.
 **Milestone "Multi-Provider"** = Issues #21–23 (mobile) + #39–42 (backend). Requires backend work first.
 
 ### Analysis screen (Issues #9 + #10) — what's implemented
@@ -142,8 +143,11 @@ BG = (0.96, 0.96, 0.96, 1)
 - Loading spinner (`MDCircularProgressIndicator`) + message
 - Empty state card with placeholder text
 - Display helpers: `show_analysis(data)`, `show_loading(bool)`, `show_empty_state()`
+- `load_for_week()` calls `get_analysis_list()` and filters by `week_start_date` (replaces old `load_latest()`)
+- `_current_analysis_id` saved in `show_analysis()`, cleared in `show_empty_state()`
+- Footer has two buttons: "Generate/Regenerate Analysis" (filled) + "Delete Analysis" (outlined, hidden when no analysis)
 - `analysis_text` attribute preserved for test compatibility
-- `on_enter` calls `load_latest()` automatically; `on_leave` clears `_active` flag
+- `on_enter` calls `load_for_week()` automatically; `on_leave` clears `_active` flag
 - `_active` flag guards all `Clock.schedule_once` callbacks — UI skipped if user navigated away
 - Week nav buttons (`_prev_btn`, `_next_btn`) disabled during generation; week label replaced with "Week navigation unavailable during generation"
 - `generate_analysis()` shows confirmation dialog before calling API
@@ -159,11 +163,24 @@ BG = (0.96, 0.96, 0.96, 1)
 - API calls run in background threads; UI updates via `Clock.schedule_once`
 - `logout()` clears token from memory and deletes the file
 
+## CI/CD
+
+- `.github/workflows/tests.yml`: runs pre-commit + pytest (with Xvfb :99 for headless Kivy)
+- `.github/workflows/android.yml`: 3-stage Android pipeline:
+  1. `validate` — runs `tests/test_buildozer.py` (fast, no Android toolchain)
+  2. `android-env` — installs buildozer + Java, validates spec with buildozer's own parser
+  3. `build-apk` — full APK build on ubuntu-22.04; only runs on push to `master` or manual dispatch; uploads APK as artifact (7-day retention)
+- `.pre-commit-config.yaml`: trailing-whitespace, end-of-file-fixer, check-yaml, check-merge-conflict, debug-statements, ruff (--fix)
+- `ruff.toml`: line-length=120, select E/F/W, ignore E501, F841 ignored in tests/
+
+**APK build note**: ubuntu-22.04 is required (24.04 ships autoconf/libtool versions that break p4a libffi). First build ~60 min; subsequent runs ~5–10 min via cached `~/.buildozer/` (SDK/NDK).
+
 ## Testing Guidelines
 
 - Always mock API calls using `unittest.mock.patch`
 - Use the `screen_manager` fixture from `conftest.py` for screen tests
 - Tests run headlessly (SDL dummy driver configured in `conftest.py`)
-- 95 tests currently passing
+- 136 tests currently passing
 - Unit tests: `tests/test_screens.py`, `tests/test_api_client.py`
+- buildozer.spec validation: `tests/test_buildozer.py` (runs in CI without full Android toolchain)
 - End-to-end flow tests: `tests/end_to_end.py` (journal and goals full cycles)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ BG = (0.96, 0.96, 0.96, 1)
 - Always mock API calls using `unittest.mock.patch`
 - Use the `screen_manager` fixture from `conftest.py` for screen tests
 - Tests run headlessly (SDL dummy driver configured in `conftest.py`)
-- 155 tests currently passing
+- 157 tests currently passing
 - Unit tests: `tests/test_screens.py`, `tests/test_api_client.py`
 - buildozer.spec validation: `tests/test_buildozer.py` (runs in CI without full Android toolchain)
 - End-to-end flow tests: `tests/end_to_end.py` (journal and goals full cycles)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ BG = (0.96, 0.96, 0.96, 1)
 - Always mock API calls using `unittest.mock.patch`
 - Use the `screen_manager` fixture from `conftest.py` for screen tests
 - Tests run headlessly (SDL dummy driver configured in `conftest.py`)
-- 136 tests currently passing
+- 155 tests currently passing
 - Unit tests: `tests/test_screens.py`, `tests/test_api_client.py`
 - buildozer.spec validation: `tests/test_buildozer.py` (runs in CI without full Android toolchain)
 - End-to-end flow tests: `tests/end_to_end.py` (journal and goals full cycles)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ BG = (0.96, 0.96, 0.96, 1)
 - Always mock API calls using `unittest.mock.patch`
 - Use the `screen_manager` fixture from `conftest.py` for screen tests
 - Tests run headlessly (SDL dummy driver configured in `conftest.py`)
-- 157 tests currently passing
+- 158 tests currently passing
 - Unit tests: `tests/test_screens.py`, `tests/test_api_client.py`
 - buildozer.spec validation: `tests/test_buildozer.py` (runs in CI without full Android toolchain)
 - End-to-end flow tests: `tests/end_to_end.py` (journal and goals full cycles)

--- a/main.py
+++ b/main.py
@@ -3,7 +3,15 @@ Coach Assistant Mobile App
 Main entry point for the KivyMD application
 """
 
+from kivy.config import Config
+
+Config.set("input", "mouse", "mouse,disable_multitouch")
+Config.set("graphics", "width", "400")
+Config.set("graphics", "height", "800")
+
 from kivymd.app import MDApp
+from kivy.clock import Clock
+from kivy.core.window import Window
 from kivy.uix.screenmanager import ScreenManager
 
 from screens import (
@@ -21,6 +29,12 @@ class CoachAssistantApp(MDApp):
 
     def build(self):
         """Build and return the root widget"""
+        Window.minimum_width = 320
+        Window.minimum_height = 500
+        Window.softinput_mode = "below_target"
+        self._resize_trigger = Clock.create_trigger(self._on_resize_settle, 0.15)
+        Window.bind(on_resize=lambda *_: self._resize_trigger())
+
         self.theme_cls.primary_palette = "Blue"
         self.theme_cls.accent_palette = "Teal"
         self.theme_cls.theme_style = "Light"
@@ -35,6 +49,11 @@ class CoachAssistantApp(MDApp):
         sm.add_widget(AnalysisScreen(name="analysis"))
 
         return sm
+
+    def _on_resize_settle(self, dt):
+        """Called once after the window stops being resized (debounced 150 ms)."""
+        if self.root:
+            self.root.do_layout()
 
     def on_start(self):
         """Called when the application starts"""

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ class CoachAssistantApp(MDApp):
         Window.softinput_mode = "below_target"
         self._resize_trigger = Clock.create_trigger(self._on_resize_settle, 0.15)
         Window.bind(on_resize=lambda *_: self._resize_trigger())
+        Window.bind(on_keyboard=self._on_keyboard)
 
         self.theme_cls.primary_palette = "Blue"
         self.theme_cls.accent_palette = "Teal"
@@ -49,6 +50,15 @@ class CoachAssistantApp(MDApp):
         sm.add_widget(AnalysisScreen(name="analysis"))
 
         return sm
+
+    def _on_keyboard(self, window, key, scancode, codepoint, modifier):
+        """Handle the Android hardware back button (key 27 = ESC/back)."""
+        if key == 27:
+            current = self.root.current
+            if current in ("goals", "journal", "analysis"):
+                self.root.current = "home"
+                return True  # consume — prevents the app from exiting
+        return False
 
     def _on_resize_settle(self, dt):
         """Called once after the window stops being resized (debounced 150 ms)."""

--- a/ruff.toml
+++ b/ruff.toml
@@ -8,3 +8,6 @@ ignore = ["E501"]  # line length handled by formatter, not linter
 "tests/**" = [
     "F841",  # unused variable (common in mock-heavy tests)
 ]
+"main.py" = [
+    "E402",  # Kivy requires Config.set() before any other kivy imports
+]

--- a/screens/analysis.py
+++ b/screens/analysis.py
@@ -4,6 +4,7 @@ import threading
 from datetime import date, timedelta
 
 from kivy.clock import Clock
+from kivy.core.clipboard import Clipboard
 from kivymd.uix.card import MDCard
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.button import MDButton, MDButtonText, MDIconButton
@@ -70,6 +71,7 @@ class AnalysisScreen(MDScreen):
         self._current_analysis_id = None
         self._status_event = None
         self._status_index = 0
+        self._analysis_plain_text = ""
         self.build_ui()
 
     def build_ui(self):
@@ -102,6 +104,15 @@ class AnalysisScreen(MDScreen):
             adaptive_height=True,
             pos_hint={"center_y": 0.5},
         ))
+        self._copy_btn = MDIconButton(
+            icon="content-copy",
+            theme_icon_color="Custom",
+            icon_color=WHITE,
+            on_release=lambda _: self._copy_analysis(),
+            opacity=0,
+            disabled=True,
+        )
+        top_row.add_widget(self._copy_btn)
         header.add_widget(top_row)
         header.add_widget(MDLabel(
             text="AI-powered insights",
@@ -365,9 +376,15 @@ class AnalysisScreen(MDScreen):
         self._prev_btn.disabled = False
         self._next_btn.disabled = False
         self.week_label.text = self._week_text()
-        for key, _, _ in _SECTIONS:
-            self._section_labels[key].text = self._format_section(data.get(key, ""))
+        parts = [f"Weekly Analysis — {self._week_text()}"]
+        for key, title, _ in _SECTIONS:
+            text = self._format_section(data.get(key, ""))
+            self._section_labels[key].text = text
             self._section_cards[key].opacity = 1
+            parts.append(f"\n{title}\n{text}")
+        self._analysis_plain_text = "\n".join(parts)
+        self._copy_btn.opacity = 1
+        self._copy_btn.disabled = False
         self._generate_btn_text.text = "Regenerate Analysis"
         self.delete_btn.opacity = 1
         self.delete_btn.disabled = False
@@ -382,6 +399,9 @@ class AnalysisScreen(MDScreen):
         self._next_btn.disabled = False
         self.week_label.text = self._week_text()
         self._hide_sections()
+        self._analysis_plain_text = ""
+        self._copy_btn.opacity = 0
+        self._copy_btn.disabled = True
         self._generate_btn_text.text = "Generate Analysis"
         self.delete_btn.opacity = 0
         self.delete_btn.disabled = True
@@ -389,6 +409,14 @@ class AnalysisScreen(MDScreen):
     def _hide_sections(self):
         for key in self._section_cards:
             self._section_cards[key].opacity = 0
+
+    def _copy_analysis(self):
+        """Copy the full analysis text to the clipboard."""
+        if not self._analysis_plain_text:
+            return
+        Clipboard.copy(self._analysis_plain_text)
+        self._copy_btn.icon = "check"
+        Clock.schedule_once(lambda _: setattr(self._copy_btn, "icon", "content-copy"), 2)
 
     # --- Navigation & API ---
 

--- a/screens/analysis.py
+++ b/screens/analysis.py
@@ -20,6 +20,7 @@ from kivymd.uix.screen import MDScreen
 from kivymd.uix.scrollview import MDScrollView
 
 from services.api_client import api_client
+from utils.debounce import debounce
 
 
 BLUE = (0.129, 0.588, 0.953, 1)
@@ -301,6 +302,7 @@ class AnalysisScreen(MDScreen):
         e = end.strftime('%b %d, %Y').replace(' 0', ' ')
         return f"{s} – {e}"
 
+    @debounce()
     def _change_week(self, delta: int):
         self._current_week_start += timedelta(weeks=delta)
         self.week_label.text = self._week_text()
@@ -410,6 +412,7 @@ class AnalysisScreen(MDScreen):
         for key in self._section_cards:
             self._section_cards[key].opacity = 0
 
+    @debounce()
     def _copy_analysis(self):
         """Copy the full analysis text to the clipboard."""
         if not self._analysis_plain_text:
@@ -420,6 +423,7 @@ class AnalysisScreen(MDScreen):
 
     # --- Navigation & API ---
 
+    @debounce()
     def go_back(self):
         """Navigate back to the home screen."""
         self.manager.current = "home"
@@ -464,6 +468,7 @@ class AnalysisScreen(MDScreen):
         else:
             self.analysis_text.text = f"Failed to {context} analysis.\n\n{message}"
 
+    @debounce()
     def generate_analysis(self, *_):
         """Show confirmation dialog before requesting a new analysis."""
         if self._dialog:
@@ -505,6 +510,7 @@ class AnalysisScreen(MDScreen):
             self._dialog.dismiss()
             self._dialog = None
 
+    @debounce()
     def _confirm_delete(self, *_):
         """Show confirmation dialog before deleting the current analysis."""
         if self._dialog:

--- a/screens/goals.py
+++ b/screens/goals.py
@@ -19,6 +19,7 @@ from kivymd.uix.dialog import (
 from kivymd.uix.textfield import MDTextField
 
 from services.api_client import api_client
+from utils.debounce import debounce
 
 
 BLUE = (0.129, 0.588, 0.953, 1)
@@ -80,9 +81,14 @@ class GoalCard(MDCard):
             size_hint=(None, None),
             size=(40, 40),
             pos_hint={"center_y": 0.5},
-            on_release=lambda x: self._on_delete(self),
+            on_release=self._handle_delete,
         )
         self.add_widget(self.delete_btn)
+
+    @debounce()
+    def _handle_delete(self, *args):
+        """Invoke the delete callback, debounced against Android's double on_release."""
+        self._on_delete(self)
 
     def on_touch_down(self, touch):
         """Toggle checkbox when the card body is tapped (excluding the delete button)."""
@@ -292,6 +298,7 @@ class GoalsScreen(MDScreen):
         """Display an error message in the status label."""
         self.status_label.text = message
 
+    @debounce()
     def show_add_dialog(self):
         """Open the dialog for entering a new goal."""
         self.new_goal_field = MDTextField(
@@ -326,6 +333,7 @@ class GoalsScreen(MDScreen):
             self._dialog.dismiss()
             self._dialog = None
 
+    @debounce()
     def confirm_add_goal(self, *args):
         """Read the dialog input, close it, and create the goal via API."""
         text = self.new_goal_field.text.strip()
@@ -344,6 +352,7 @@ class GoalsScreen(MDScreen):
 
         threading.Thread(target=_do, daemon=True).start()
 
+    @debounce()
     def go_back(self):
         """Navigate back to the home screen."""
         self.manager.current = "home"

--- a/screens/home.py
+++ b/screens/home.py
@@ -54,23 +54,25 @@ class StatCard(MDCard):
             style="elevated",
             **kwargs,
         )
-        top_row = MDBoxLayout(orientation="horizontal", spacing=8, adaptive_height=True)
+        top_row = MDBoxLayout(orientation="horizontal", spacing=8, size_hint=(1, 0.55))
         top_row.add_widget(MDLabel(
             text=md_icons.get(icon, ""),
             font_style="Icon",
             font_size="20sp",
-            size_hint=(None, None),
-            size=(24, 24),
+            size_hint=(None, 1),
+            width=24,
             theme_text_color="Custom",
             text_color=BLUE,
+            valign="center",
         ))
         self.value_label = MDLabel(
             text=value,
             font_style="Title",
             role="large",
-            adaptive_height=True,
+            size_hint=(1, 1),
             theme_text_color="Custom",
             text_color=BLUE,
+            valign="center",
         )
         top_row.add_widget(self.value_label)
         self.add_widget(top_row)
@@ -79,7 +81,9 @@ class StatCard(MDCard):
             font_style="Body",
             role="small",
             theme_text_color="Secondary",
-            adaptive_height=True,
+            size_hint=(1, 0.45),
+            valign="top",
+            halign="left",
         ))
 
 
@@ -100,7 +104,7 @@ class NavCard(MDCard):
             padding=[20, 18, 20, 18],
             spacing=20,
             size_hint=(1, None),
-            height=88,
+            height=130,
             elevation=1,
             style="elevated",
             ripple_behavior=True,
@@ -119,19 +123,27 @@ class NavCard(MDCard):
             text_color=BLUE,
         ))
 
-        text_col = MDBoxLayout(orientation="vertical", spacing=2)
+        text_col = MDBoxLayout(
+            orientation="vertical",
+            size_hint=(1, 1),
+            padding=[0, 10, 0, 10],
+        )
         text_col.add_widget(MDLabel(
             text=title,
             font_style="Title",
             role="medium",
-            adaptive_height=True,
+            size_hint_y=0.55,
+            valign="bottom",
+            halign="left",
         ))
         text_col.add_widget(MDLabel(
             text=subtitle,
             font_style="Body",
             role="small",
             theme_text_color="Secondary",
-            adaptive_height=True,
+            size_hint_y=0.45,
+            valign="top",
+            halign="left",
         ))
         self.add_widget(text_col)
 
@@ -176,7 +188,7 @@ class HomeScreen(MDScreen):
         )
 
         top_row = MDBoxLayout(orientation="horizontal", adaptive_height=True)
-        title_col = MDBoxLayout(orientation="vertical", spacing=4)
+        title_col = MDBoxLayout(orientation="vertical", spacing=4, size_hint_x=1, adaptive_height=True)
         self.greeting_label = MDLabel(
             text=f"{_greeting()}!",
             font_style="Display",
@@ -214,7 +226,7 @@ class HomeScreen(MDScreen):
         inner = MDBoxLayout(
             orientation="vertical",
             padding=[16, 16, 16, 16],
-            spacing=14,
+            spacing=18,
             adaptive_height=True,
         )
 
@@ -252,7 +264,7 @@ class HomeScreen(MDScreen):
         ))
 
         # Logout
-        logout_row = MDBoxLayout(size_hint=(1, None), height=56, padding=[0, 8, 0, 0])
+        logout_row = MDBoxLayout(size_hint=(1, None), height=80, padding=[0, 40, 0, 0])
         logout_btn = MDButton(
             style="text",
             theme_width="Custom",

--- a/screens/home.py
+++ b/screens/home.py
@@ -13,6 +13,7 @@ from kivymd.uix.card import MDCard
 from kivymd.icon_definitions import md_icons
 
 from services.api_client import api_client
+from utils.debounce import debounce
 
 
 BLUE = (0.129, 0.588, 0.953, 1)
@@ -287,6 +288,7 @@ class HomeScreen(MDScreen):
         self.username_label.text = f"Welcome back, {name}" if name else "What would you like to do today?"
         self.load_stats()
 
+    @debounce()
     def load_stats(self):
         """Load goal and journal counts from API in background thread"""
         def _fetch():
@@ -316,6 +318,7 @@ class HomeScreen(MDScreen):
         """Navigate to the given screen by name."""
         self.manager.current = screen_name
 
+    @debounce()
     def do_logout(self, *args):
         """Clear the auth token and return to the login screen."""
         api_client.logout()

--- a/screens/journal.py
+++ b/screens/journal.py
@@ -18,6 +18,7 @@ from kivymd.uix.dialog import (
 from kivy.uix.textinput import TextInput
 
 from services.api_client import api_client
+from utils.debounce import debounce
 
 
 BLUE = (0.129, 0.588, 0.953, 1)
@@ -182,6 +183,7 @@ class JournalScreen(MDScreen):
         """Load the journal entry for the current date each time the screen is shown."""
         self.load_entry(self.current_date)
 
+    @debounce()
     def navigate_date(self, delta):
         """Navigate to the previous (-1) or next (+1) day, prompting if unsaved changes exist."""
         if self._has_unsaved_changes():
@@ -230,6 +232,7 @@ class JournalScreen(MDScreen):
         self._entry_id = entry_id
         self.status_label.text = ""
 
+    @debounce()
     def save_entry(self, *args):
         """Save the current journal entry via the API (Issue #8)."""
         content = self.journal_field.text.strip()
@@ -271,6 +274,7 @@ class JournalScreen(MDScreen):
         self.save_btn_text.text = "Save Entry"
         self.status_label.text = "Could not save. Please try again."
 
+    @debounce()
     def go_back(self):
         """Navigate back to home, showing a discard dialog if there are unsaved changes."""
         if self._has_unsaved_changes():

--- a/screens/login.py
+++ b/screens/login.py
@@ -192,6 +192,11 @@ class LoginScreen(MDScreen):
     def toggle_password_visibility(self, *args):
         """Toggle the password field between plain text and masked input."""
         self.password_field.password = not self.password_field.password
+        # KivyMD 2.x doesn't re-render existing text when password mode changes at runtime.
+        # Reassigning the text forces the field to redraw with the new mode.
+        text = self.password_field.text
+        self.password_field.text = ""
+        self.password_field.text = text
         self.eye_btn.icon = "eye-off" if not self.password_field.password else "eye"
 
     def toggle_mode(self, *args):

--- a/screens/login.py
+++ b/screens/login.py
@@ -4,6 +4,9 @@ import threading
 
 import requests
 from kivy.clock import Clock
+from kivy.metrics import dp
+
+from utils.debounce import debounce
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.textfield import MDTextField, MDTextFieldLeadingIcon
@@ -97,20 +100,23 @@ class LoginScreen(MDScreen):
         password_row = MDBoxLayout(
             orientation="horizontal",
             spacing=4,
-            size_hint_x=1,
-            adaptive_height=True,
+            size_hint=(1, None),
+            height=dp(56),
         )
         self.password_field = MDTextField(
             mode="outlined",
             hint_text="Password",
             password=True,
-            size_hint_x=1,
+            size_hint=(1, 1),
         )
         self.password_field.add_widget(MDTextFieldLeadingIcon(icon="lock"))
         password_row.add_widget(self.password_field)
 
         self.eye_btn = MDIconButton(
             icon="eye",
+            size_hint=(None, None),
+            size=(dp(48), dp(48)),
+            pos_hint={"center_y": 0.5},
             on_release=self.toggle_password_visibility,
         )
         password_row.add_widget(self.eye_btn)
@@ -189,15 +195,25 @@ class LoginScreen(MDScreen):
         """Clear any displayed error message."""
         self.error_label.text = ""
 
+    @debounce()
     def toggle_password_visibility(self, *args):
-        """Toggle the password field between plain text and masked input."""
-        self.password_field.password = not self.password_field.password
-        # KivyMD 2.x doesn't re-render existing text when password mode changes at runtime.
-        # Reassigning the text forces the field to redraw with the new mode.
-        text = self.password_field.text
-        self.password_field.text = ""
-        self.password_field.text = text
-        self.eye_btn.icon = "eye-off" if not self.password_field.password else "eye"
+        """Toggle the password field between plain text and masked input.
+
+        Debounced because Android dispatches ``on_release`` twice per physical
+        tap (~1 ms apart); without it the field would toggle twice and end up
+        unchanged.
+        """
+        field = self.password_field
+        field.password = not field.password
+        # Update the icon first so the tap always gives visible feedback even if
+        # the field's re-render lags.
+        self.eye_btn.icon = "eye-off" if not field.password else "eye"
+        # Force the field to repaint with the new masking (KivyMD 2.x doesn't
+        # always re-render when `password` flips at runtime).
+        try:
+            field._refresh_text(field.text)
+        except Exception:
+            pass
 
     def toggle_mode(self, *args):
         """Switch between login and register modes, updating all labels."""
@@ -234,6 +250,7 @@ class LoginScreen(MDScreen):
     # Actions
     # ------------------------------------------------------------------
 
+    @debounce()
     def do_action(self, *args):
         """Validate inputs then dispatch to do_login or do_register."""
         self.clear_error()

--- a/services/api_client.py
+++ b/services/api_client.py
@@ -22,9 +22,12 @@ class APIClient:
     # For phone testing: change to your laptop's local IP, e.g. http://192.168.1.x:8000/api
     API_BASE_URL = "http://localhost:8000/api"
 
+    REQUEST_TIMEOUT = 15  # seconds
+
     def __init__(self):
         """Initialise the client with empty auth state."""
         self.token: Optional[str] = None
+        self.refresh_token: Optional[str] = None
         self.username: Optional[str] = None
         self.headers = {"Content-Type": "application/json"}
 
@@ -54,6 +57,7 @@ class APIClient:
         # Backend returns tokens.access (JWT) or token (simple)
         tokens_obj = result.get("tokens", {})
         self.token = tokens_obj.get("access") or result.get("token")
+        self.refresh_token = tokens_obj.get("refresh")
         self.username = result.get("user", {}).get("username") or username
         self._update_auth_header()
         self.save_token()
@@ -81,18 +85,23 @@ class APIClient:
         return response.json()
 
     def save_token(self):
-        """Persist the current access token and username to disk"""
+        """Persist the current access and refresh tokens to disk"""
         if self.token:
             with open(TOKEN_FILE, "w") as f:
-                json.dump({"access_token": self.token, "username": self.username}, f)
+                json.dump({
+                    "access_token": self.token,
+                    "refresh_token": self.refresh_token,
+                    "username": self.username,
+                }, f)
 
     def load_token(self) -> Optional[str]:
-        """Load persisted token and username from disk"""
+        """Load persisted tokens and username from disk"""
         if os.path.exists(TOKEN_FILE):
             try:
                 with open(TOKEN_FILE) as f:
                     data = json.load(f)
                 self.token = data.get("access_token")
+                self.refresh_token = data.get("refresh_token")
                 self.username = data.get("username")
                 if self.token:
                     self._update_auth_header()
@@ -102,12 +111,43 @@ class APIClient:
         return None
 
     def logout(self):
-        """Clear token and username from memory and disk"""
+        """Clear tokens and username from memory and disk"""
         self.token = None
+        self.refresh_token = None
         self.username = None
         self.headers.pop("Authorization", None)
         if os.path.exists(TOKEN_FILE):
             os.remove(TOKEN_FILE)
+
+    def _refresh_access_token(self) -> bool:
+        """Use the refresh token to obtain a new access token. Returns True on success."""
+        if not self.refresh_token:
+            return False
+        url = f"{self.API_BASE_URL}/auth/token/refresh/"
+        try:
+            response = requests.post(
+                url, json={"refresh": self.refresh_token}, timeout=self.REQUEST_TIMEOUT
+            )
+            if response.status_code == 200:
+                self.token = response.json().get("access")
+                if self.token:
+                    self._update_auth_header()
+                    self.save_token()
+                    return True
+        except Exception:
+            pass
+        return False
+
+    def _request(self, method: str, url: str, **kwargs) -> requests.Response:
+        """Make an HTTP request with timeout, retrying once after a token refresh on 401."""
+        kwargs.setdefault("headers", self.headers)
+        kwargs.setdefault("timeout", self.REQUEST_TIMEOUT)
+        response = getattr(requests, method)(url, **kwargs)
+        if response.status_code == 401 and self._refresh_access_token():
+            kwargs["headers"] = self.headers
+            response = getattr(requests, method)(url, **kwargs)
+        response.raise_for_status()
+        return response
 
     def is_authenticated(self) -> bool:
         """Return True if a token is currently set"""
@@ -116,94 +156,80 @@ class APIClient:
     # Goals endpoints
     def get_goals(self) -> List[Dict]:
         """Get all goals for current week"""
-        url = f"{self.API_BASE_URL}/goals/"
-        response = requests.get(url, headers=self.headers)
-        response.raise_for_status()
-        return response.json()
+        return self._request("get", f"{self.API_BASE_URL}/goals/").json()
 
     def create_goal(self, goal_text: str, category: str = "personal") -> Dict:
         """Create new weekly goal for the current week."""
-        url = f"{self.API_BASE_URL}/goals/"
         today = date.today()
-        week_start = today - timedelta(days=today.weekday())  # Monday
+        week_start = today - timedelta(days=today.weekday())
         data = {
             "goal_text": goal_text,
             "category": category,
             "week_start_date": week_start.isoformat(),
         }
-        response = requests.post(url, json=data, headers=self.headers)
-        response.raise_for_status()
-        return response.json()
+        return self._request("post", f"{self.API_BASE_URL}/goals/", json=data).json()
 
     def update_goal(
-        self, goal_id: int, completed: Optional[bool] = None, goal_text: Optional[str] = None
+        self,
+        goal_id: int,
+        completed: Optional[bool] = None,
+        goal_text: Optional[str] = None,
     ) -> Dict:
         """Update goal status or text"""
-        url = f"{self.API_BASE_URL}/goals/{goal_id}/"
         data = {}
         if completed is not None:
             data["completed"] = completed
         if goal_text is not None:
             data["goal_text"] = goal_text
-
-        response = requests.patch(url, json=data, headers=self.headers)
-        response.raise_for_status()
-        return response.json()
+        return self._request("patch", f"{self.API_BASE_URL}/goals/{goal_id}/", json=data).json()
 
     def delete_goal(self, goal_id: int) -> None:
         """Delete a goal by ID"""
-        url = f"{self.API_BASE_URL}/goals/{goal_id}/"
-        response = requests.delete(url, headers=self.headers)
-        response.raise_for_status()
+        self._request("delete", f"{self.API_BASE_URL}/goals/{goal_id}/")
 
     # Journal endpoints
     def get_journal_entries(self) -> List[Dict]:
         """Get all journal entries"""
-        url = f"{self.API_BASE_URL}/journal/"
-        response = requests.get(url, headers=self.headers)
-        response.raise_for_status()
-        return response.json()
+        return self._request("get", f"{self.API_BASE_URL}/journal/").json()
 
     def get_journal_by_date(self, date_str: str) -> Optional[Dict]:
         """Get journal entry for specific date (YYYY-MM-DD)"""
         url = f"{self.API_BASE_URL}/journal/by-date/{date_str}/"
-        response = requests.get(url, headers=self.headers)
+        response = requests.get(url, headers=self.headers, timeout=self.REQUEST_TIMEOUT)
+        if response.status_code == 401 and self._refresh_access_token():
+            response = requests.get(url, headers=self.headers, timeout=self.REQUEST_TIMEOUT)
         if response.status_code == 404:
             return None
         response.raise_for_status()
         return response.json()
 
-    def create_journal_entry(
-        self, date_str: str, content: str, language: str = "en"
-    ) -> Dict:
+    def create_journal_entry(self, date_str: str, content: str, language: str = "en") -> Dict:
         """Create new journal entry"""
-        url = f"{self.API_BASE_URL}/journal/"
         data = {"date": date_str, "content": content, "language": language}
-        response = requests.post(url, json=data, headers=self.headers)
-        response.raise_for_status()
-        return response.json()
+        return self._request("post", f"{self.API_BASE_URL}/journal/", json=data).json()
 
     def update_journal_entry(self, entry_id: int, content: str) -> Dict:
         """Update existing journal entry by ID"""
-        url = f"{self.API_BASE_URL}/journal/{entry_id}/"
-        data = {"content": content}
-        response = requests.patch(url, json=data, headers=self.headers)
-        response.raise_for_status()
-        return response.json()
+        return self._request(
+            "patch", f"{self.API_BASE_URL}/journal/{entry_id}/", json={"content": content}
+        ).json()
 
     # Analysis endpoints
     def generate_analysis(self, week_start_date: str) -> Dict:
         """Request weekly analysis generation"""
-        url = f"{self.API_BASE_URL}/analysis/generate/"
-        data = {"week_start_date": week_start_date}
-        response = requests.post(url, json=data, headers=self.headers)
-        response.raise_for_status()
-        return response.json()
+        return self._request(
+            "post",
+            f"{self.API_BASE_URL}/analysis/generate/",
+            json={"week_start_date": week_start_date},
+            timeout=120,  # generation can take up to 30-60s
+        ).json()
 
     def get_latest_analysis(self) -> Optional[Dict]:
         """Get most recent weekly analysis"""
         url = f"{self.API_BASE_URL}/analysis/latest/"
-        response = requests.get(url, headers=self.headers)
+        response = requests.get(url, headers=self.headers, timeout=self.REQUEST_TIMEOUT)
+        if response.status_code == 401 and self._refresh_access_token():
+            response = requests.get(url, headers=self.headers, timeout=self.REQUEST_TIMEOUT)
         if response.status_code == 404:
             return None
         response.raise_for_status()
@@ -212,7 +238,9 @@ class APIClient:
     def get_analysis_list(self) -> List[Dict]:
         """Get all weekly analyses for the current user"""
         url = f"{self.API_BASE_URL}/analysis/"
-        response = requests.get(url, headers=self.headers)
+        response = requests.get(url, headers=self.headers, timeout=self.REQUEST_TIMEOUT)
+        if response.status_code == 401 and self._refresh_access_token():
+            response = requests.get(url, headers=self.headers, timeout=self.REQUEST_TIMEOUT)
         if response.status_code == 404:
             return []
         response.raise_for_status()
@@ -220,9 +248,7 @@ class APIClient:
 
     def delete_analysis(self, analysis_id: int) -> None:
         """Delete an analysis by ID"""
-        url = f"{self.API_BASE_URL}/analysis/{analysis_id}/"
-        response = requests.delete(url, headers=self.headers)
-        response.raise_for_status()
+        self._request("delete", f"{self.API_BASE_URL}/analysis/{analysis_id}/")
 
 
 # Singleton instance

--- a/services/api_client.py
+++ b/services/api_client.py
@@ -146,7 +146,7 @@ class APIClient:
         if goal_text is not None:
             data["goal_text"] = goal_text
 
-        response = requests.put(url, json=data, headers=self.headers)
+        response = requests.patch(url, json=data, headers=self.headers)
         response.raise_for_status()
         return response.json()
 

--- a/services/api_client.py
+++ b/services/api_client.py
@@ -120,7 +120,13 @@ class APIClient:
             os.remove(TOKEN_FILE)
 
     def _refresh_access_token(self) -> bool:
-        """Use the refresh token to obtain a new access token. Returns True on success."""
+        """Use the refresh token to obtain a new access token. Returns True on success.
+
+        If the server rejects the refresh token (401 — it has expired or been
+        revoked), the stored session is cleared so the app falls back to the
+        login screen instead of looping on 401s with a dead token. Network/
+        connection errors leave the token intact so a later retry can succeed.
+        """
         if not self.refresh_token:
             return False
         url = f"{self.API_BASE_URL}/auth/token/refresh/"
@@ -128,25 +134,34 @@ class APIClient:
             response = requests.post(
                 url, json={"refresh": self.refresh_token}, timeout=self.REQUEST_TIMEOUT
             )
-            if response.status_code == 200:
-                self.token = response.json().get("access")
-                if self.token:
-                    self._update_auth_header()
-                    self.save_token()
-                    return True
         except Exception:
-            pass
+            return False
+        if response.status_code == 200:
+            self.token = response.json().get("access")
+            if self.token:
+                self._update_auth_header()
+                self.save_token()
+                return True
+        elif response.status_code == 401:
+            self.logout()
         return False
 
-    def _request(self, method: str, url: str, **kwargs) -> requests.Response:
-        """Make an HTTP request with timeout, retrying once after a token refresh on 401."""
+    def _request(
+        self, method: str, url: str, allow_statuses: tuple = (), **kwargs
+    ) -> requests.Response:
+        """Make an HTTP request with timeout, retrying once after a token refresh on 401.
+
+        Statuses listed in ``allow_statuses`` (e.g. 404) are returned to the
+        caller without raising, so endpoints can map them to None/[] themselves.
+        """
         kwargs.setdefault("headers", self.headers)
         kwargs.setdefault("timeout", self.REQUEST_TIMEOUT)
         response = getattr(requests, method)(url, **kwargs)
         if response.status_code == 401 and self._refresh_access_token():
             kwargs["headers"] = self.headers
             response = getattr(requests, method)(url, **kwargs)
-        response.raise_for_status()
+        if response.status_code not in allow_statuses:
+            response.raise_for_status()
         return response
 
     def is_authenticated(self) -> bool:
@@ -195,12 +210,9 @@ class APIClient:
     def get_journal_by_date(self, date_str: str) -> Optional[Dict]:
         """Get journal entry for specific date (YYYY-MM-DD)"""
         url = f"{self.API_BASE_URL}/journal/by-date/{date_str}/"
-        response = requests.get(url, headers=self.headers, timeout=self.REQUEST_TIMEOUT)
-        if response.status_code == 401 and self._refresh_access_token():
-            response = requests.get(url, headers=self.headers, timeout=self.REQUEST_TIMEOUT)
+        response = self._request("get", url, allow_statuses=(404,))
         if response.status_code == 404:
             return None
-        response.raise_for_status()
         return response.json()
 
     def create_journal_entry(self, date_str: str, content: str, language: str = "en") -> Dict:
@@ -227,23 +239,17 @@ class APIClient:
     def get_latest_analysis(self) -> Optional[Dict]:
         """Get most recent weekly analysis"""
         url = f"{self.API_BASE_URL}/analysis/latest/"
-        response = requests.get(url, headers=self.headers, timeout=self.REQUEST_TIMEOUT)
-        if response.status_code == 401 and self._refresh_access_token():
-            response = requests.get(url, headers=self.headers, timeout=self.REQUEST_TIMEOUT)
+        response = self._request("get", url, allow_statuses=(404,))
         if response.status_code == 404:
             return None
-        response.raise_for_status()
         return response.json()
 
     def get_analysis_list(self) -> List[Dict]:
         """Get all weekly analyses for the current user"""
         url = f"{self.API_BASE_URL}/analysis/"
-        response = requests.get(url, headers=self.headers, timeout=self.REQUEST_TIMEOUT)
-        if response.status_code == 401 and self._refresh_access_token():
-            response = requests.get(url, headers=self.headers, timeout=self.REQUEST_TIMEOUT)
+        response = self._request("get", url, allow_statuses=(404,))
         if response.status_code == 404:
             return []
-        response.raise_for_status()
         return response.json()
 
     def delete_analysis(self, analysis_id: int) -> None:

--- a/services/api_client.py
+++ b/services/api_client.py
@@ -94,11 +94,14 @@ class APIClient:
         """Persist the current access and refresh tokens to disk"""
         if self.token:
             with open(TOKEN_FILE, "w") as f:
-                json.dump({
-                    "access_token": self.token,
-                    "refresh_token": self.refresh_token,
-                    "username": self.username,
-                }, f)
+                json.dump(
+                    {
+                        "access_token": self.token,
+                        "refresh_token": self.refresh_token,
+                        "username": self.username,
+                    },
+                    f,
+                )
 
     def load_token(self) -> Optional[str]:
         """Load persisted tokens and username from disk"""
@@ -148,7 +151,9 @@ class APIClient:
             url = f"{self.API_BASE_URL}/auth/token/refresh/"
             try:
                 response = requests.post(
-                    url, json={"refresh": self.refresh_token}, timeout=self.REQUEST_TIMEOUT
+                    url,
+                    json={"refresh": self.refresh_token},
+                    timeout=self.REQUEST_TIMEOUT,
                 )
             except Exception:
                 return False
@@ -212,7 +217,9 @@ class APIClient:
             data["completed"] = completed
         if goal_text is not None:
             data["goal_text"] = goal_text
-        return self._request("patch", f"{self.API_BASE_URL}/goals/{goal_id}/", json=data).json()
+        return self._request(
+            "patch", f"{self.API_BASE_URL}/goals/{goal_id}/", json=data
+        ).json()
 
     def delete_goal(self, goal_id: int) -> None:
         """Delete a goal by ID"""
@@ -231,7 +238,9 @@ class APIClient:
             return None
         return response.json()
 
-    def create_journal_entry(self, date_str: str, content: str, language: str = "en") -> Dict:
+    def create_journal_entry(
+        self, date_str: str, content: str, language: str = "en"
+    ) -> Dict:
         """Create new journal entry"""
         data = {"date": date_str, "content": content, "language": language}
         return self._request("post", f"{self.API_BASE_URL}/journal/", json=data).json()
@@ -239,7 +248,9 @@ class APIClient:
     def update_journal_entry(self, entry_id: int, content: str) -> Dict:
         """Update existing journal entry by ID"""
         return self._request(
-            "patch", f"{self.API_BASE_URL}/journal/{entry_id}/", json={"content": content}
+            "patch",
+            f"{self.API_BASE_URL}/journal/{entry_id}/",
+            json={"content": content},
         ).json()
 
     # Analysis endpoints

--- a/services/api_client.py
+++ b/services/api_client.py
@@ -4,6 +4,7 @@ API Client for communicating with Django backend
 
 import os
 import json
+import threading
 from datetime import date, timedelta
 import requests
 from typing import Optional, Dict, List
@@ -30,6 +31,11 @@ class APIClient:
         self.refresh_token: Optional[str] = None
         self.username: Optional[str] = None
         self.headers = {"Content-Type": "application/json"}
+        # Serialises token refreshes: API calls run on background threads, so
+        # several can hit a 401 at once. Without this they would each fire a
+        # refresh, and if the backend ever rotates refresh tokens the extra
+        # calls would invalidate each other's tokens.
+        self._refresh_lock = threading.Lock()
 
     def _update_auth_header(self):
         """Update authorization header with current token"""
@@ -126,25 +132,35 @@ class APIClient:
         revoked), the stored session is cleared so the app falls back to the
         login screen instead of looping on 401s with a dead token. Network/
         connection errors leave the token intact so a later retry can succeed.
+
+        The refresh is serialised: concurrent callers that block on the lock
+        re-check whether another thread already refreshed and reuse its result
+        instead of firing a second refresh.
         """
         if not self.refresh_token:
             return False
-        url = f"{self.API_BASE_URL}/auth/token/refresh/"
-        try:
-            response = requests.post(
-                url, json={"refresh": self.refresh_token}, timeout=self.REQUEST_TIMEOUT
-            )
-        except Exception:
-            return False
-        if response.status_code == 200:
-            self.token = response.json().get("access")
-            if self.token:
-                self._update_auth_header()
-                self.save_token()
+        # Token in use when our request failed; if it changes while we wait for
+        # the lock, another thread already refreshed and we can reuse it.
+        stale_token = self.token
+        with self._refresh_lock:
+            if self.token != stale_token:
                 return True
-        elif response.status_code == 401:
-            self.logout()
-        return False
+            url = f"{self.API_BASE_URL}/auth/token/refresh/"
+            try:
+                response = requests.post(
+                    url, json={"refresh": self.refresh_token}, timeout=self.REQUEST_TIMEOUT
+                )
+            except Exception:
+                return False
+            if response.status_code == 200:
+                self.token = response.json().get("access")
+                if self.token:
+                    self._update_auth_header()
+                    self.save_token()
+                    return True
+            elif response.status_code == 401:
+                self.logout()
+            return False
 
     def _request(
         self, method: str, url: str, allow_statuses: tuple = (), **kwargs

--- a/services/api_client.py
+++ b/services/api_client.py
@@ -50,7 +50,7 @@ class APIClient:
         url = f"{self.API_BASE_URL}/auth/login/"
         data = {"username": username, "password": password}
 
-        response = requests.post(url, json=data)
+        response = requests.post(url, json=data, timeout=self.REQUEST_TIMEOUT)
         response.raise_for_status()
 
         result = response.json()
@@ -79,7 +79,7 @@ class APIClient:
         url = f"{self.API_BASE_URL}/auth/register/"
         data = {"username": username, "password": password, "email": email}
 
-        response = requests.post(url, json=data)
+        response = requests.post(url, json=data, timeout=self.REQUEST_TIMEOUT)
         response.raise_for_status()
 
         return response.json()

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -256,3 +256,140 @@ class TestAPIClient:
         result = client.get_latest_analysis()
 
         assert result is None
+
+
+class TestTokenRefresh:
+    """Tests for automatic JWT token refresh on 401.
+
+    Root cause: access tokens expire after 5 minutes (Django SimpleJWT default).
+    The app was not saving or using the refresh token, so every request would fail
+    silently with 401 after 5 minutes. Fix: save refresh token at login, and retry
+    any 401 response once after refreshing the access token.
+    """
+
+    def test_login_saves_refresh_token(self):
+        """login() must store the refresh token from tokens.refresh."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "tokens": {"access": "access-tok", "refresh": "refresh-tok"},
+            "user": {"username": "u"},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        client = APIClient()
+        with patch("services.api_client.requests.post", return_value=mock_response), \
+             patch("services.api_client.open", create=True), \
+             patch("services.api_client.json.dump"):
+            client.login("u", "p")
+
+        assert client.refresh_token == "refresh-tok"
+
+    def test_save_and_load_refresh_token(self, tmp_path, monkeypatch):
+        """Refresh token must survive a save/load round-trip."""
+        token_file = tmp_path / "token.json"
+        monkeypatch.setattr("services.api_client.TOKEN_FILE", str(token_file))
+
+        client = APIClient()
+        client.token = "access-tok"
+        client.refresh_token = "refresh-tok"
+        client.username = "u"
+        client.save_token()
+
+        client2 = APIClient()
+        monkeypatch.setattr("services.api_client.TOKEN_FILE", str(token_file))
+        client2.load_token()
+
+        assert client2.refresh_token == "refresh-tok"
+
+    @patch("services.api_client.requests.post")
+    def test_refresh_access_token_success(self, mock_post):
+        """_refresh_access_token() updates the access token and returns True."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access": "new-access-tok"}
+        mock_post.return_value = mock_response
+
+        client = APIClient()
+        client.refresh_token = "refresh-tok"
+
+        with patch.object(client, "save_token"):
+            result = client._refresh_access_token()
+
+        assert result is True
+        assert client.token == "new-access-tok"
+        assert client.headers["Authorization"] == "Bearer new-access-tok"
+
+    def test_refresh_access_token_no_refresh_token(self):
+        """_refresh_access_token() returns False when no refresh token is stored."""
+        client = APIClient()
+        client.refresh_token = None
+
+        assert client._refresh_access_token() is False
+
+    @patch("services.api_client.requests.post", side_effect=Exception("network error"))
+    def test_refresh_access_token_network_failure(self, _):
+        """_refresh_access_token() returns False on network error."""
+        client = APIClient()
+        client.refresh_token = "refresh-tok"
+
+        assert client._refresh_access_token() is False
+
+    @patch("services.api_client.requests.get")
+    def test_request_retries_after_401_and_succeeds(self, mock_get):
+        """_request() retries once with a new token when the first response is 401."""
+        expired_response = MagicMock()
+        expired_response.status_code = 401
+
+        ok_response = MagicMock()
+        ok_response.status_code = 200
+        ok_response.json.return_value = {"id": 1}
+
+        mock_get.side_effect = [expired_response, ok_response]
+
+        client = APIClient()
+        client.refresh_token = "refresh-tok"
+
+        with patch.object(client, "_refresh_access_token", return_value=True):
+            response = client._request("get", "http://test/api/goals/")
+
+        assert mock_get.call_count == 2
+        assert response.status_code == 200
+
+    @patch("services.api_client.requests.get")
+    def test_request_raises_401_when_refresh_fails(self, mock_get):
+        """_request() raises HTTPError when 401 persists after a failed refresh."""
+        import requests as req
+
+        expired_response = MagicMock()
+        expired_response.status_code = 401
+        expired_response.raise_for_status.side_effect = req.HTTPError("401")
+        mock_get.return_value = expired_response
+
+        client = APIClient()
+        with patch.object(client, "_refresh_access_token", return_value=False):
+            try:
+                client._request("get", "http://test/api/goals/")
+                assert False, "Expected HTTPError"
+            except req.HTTPError:
+                pass
+
+    @patch("services.api_client.requests.get")
+    def test_get_goals_auto_refreshes_on_401(self, mock_get):
+        """get_goals() transparently refreshes the token and retries on 401."""
+        expired = MagicMock()
+        expired.status_code = 401
+
+        ok = MagicMock()
+        ok.status_code = 200
+        ok.json.return_value = [{"id": 1, "goal_text": "Run"}]
+
+        mock_get.side_effect = [expired, ok]
+
+        client = APIClient()
+        client.refresh_token = "refresh-tok"
+
+        with patch.object(client, "_refresh_access_token", return_value=True):
+            result = client.get_goals()
+
+        assert result == [{"id": 1, "goal_text": "Run"}]
+        assert mock_get.call_count == 2

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -175,6 +175,21 @@ class TestAPIClient:
         expected_monday = (today - timedelta(days=today.weekday())).isoformat()
         assert payload["week_start_date"] == expected_monday
 
+    @patch("services.api_client.requests.patch")
+    def test_update_goal_uses_patch(self, mock_patch):
+        """update_goal must use PATCH (not PUT) — PUT returns 400 Bad Request."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": 7, "completed": True}
+        mock_response.raise_for_status = MagicMock()
+        mock_patch.return_value = mock_response
+
+        client = APIClient()
+        client.update_goal(7, completed=True)
+
+        mock_patch.assert_called_once()
+        assert "goals/7/" in mock_patch.call_args[0][0]
+        assert mock_patch.call_args[1]["json"]["completed"] is True
+
     @patch("services.api_client.requests.delete")
     def test_delete_goal(self, mock_delete):
         """Test delete_goal sends DELETE request"""

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -328,11 +328,36 @@ class TestTokenRefresh:
 
     @patch("services.api_client.requests.post", side_effect=Exception("network error"))
     def test_refresh_access_token_network_failure(self, _):
-        """_refresh_access_token() returns False on network error."""
+        """_refresh_access_token() returns False on network error, keeping the token."""
         client = APIClient()
+        client.token = "old-access-tok"
         client.refresh_token = "refresh-tok"
 
         assert client._refresh_access_token() is False
+        # Network error must NOT wipe the session — a later retry may succeed.
+        assert client.token == "old-access-tok"
+        assert client.refresh_token == "refresh-tok"
+
+    @patch("services.api_client.requests.post")
+    def test_refresh_access_token_expired_clears_session(self, mock_post):
+        """A 401 from the refresh endpoint (expired/revoked) clears the session."""
+        rejected = MagicMock()
+        rejected.status_code = 401
+        mock_post.return_value = rejected
+
+        client = APIClient()
+        client.token = "dead-access-tok"
+        client.refresh_token = "expired-refresh-tok"
+        client._update_auth_header()
+
+        with patch.object(client, "logout", wraps=client.logout) as mock_logout:
+            result = client._refresh_access_token()
+
+        assert result is False
+        mock_logout.assert_called_once()
+        assert client.token is None
+        assert client.refresh_token is None
+        assert "Authorization" not in client.headers
 
     @patch("services.api_client.requests.get")
     def test_request_retries_after_401_and_succeeds(self, mock_get):

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -385,6 +385,31 @@ class TestTokenRefresh:
         assert client.refresh_token is None
         assert "Authorization" not in client.headers
 
+    @patch("services.api_client.requests.post")
+    def test_refresh_access_token_skips_when_already_refreshed(self, mock_post):
+        """If another thread refreshed the access token while we waited for the
+        lock, reuse it instead of firing a redundant (rotation-unsafe) refresh."""
+        client = APIClient()
+        client.token = "stale-tok"
+        client.refresh_token = "refresh-tok"
+
+        # Simulate a concurrent refresh completing while we block on the lock:
+        # entering the lock swaps in a freshly-refreshed access token, so the
+        # in-lock re-check sees token != stale_token and returns early.
+        class FakeLock:
+            def __enter__(self):
+                client.token = "concurrently-refreshed-tok"
+
+            def __exit__(self, *exc):
+                return False
+
+        client._refresh_lock = FakeLock()
+
+        result = client._refresh_access_token()
+
+        assert result is True
+        mock_post.assert_not_called()
+
     @patch("services.api_client.requests.get")
     def test_request_retries_after_401_and_succeeds(self, mock_get):
         """_request() retries once with a new token when the first response is 401."""

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -90,6 +90,32 @@ class TestAPIClient:
         call_args = mock_post.call_args
         assert "register" in call_args[0][0]
 
+    @patch("services.api_client.requests.post")
+    def test_login_uses_timeout(self, mock_post):
+        """login() must pass a timeout so a hung connection can't freeze the auth thread."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"token": "abc123", "user": {"id": 1}}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        client = APIClient()
+        with patch("builtins.open", MagicMock()), patch("services.api_client.json.dump"):
+            client.login("testuser", "password")
+
+        assert mock_post.call_args.kwargs["timeout"] == APIClient.REQUEST_TIMEOUT
+
+    @patch("services.api_client.requests.post")
+    def test_register_uses_timeout(self, mock_post):
+        """register() must pass a timeout so a hung connection can't freeze the auth thread."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": 1, "username": "newuser"}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        APIClient().register("newuser", "password", "email@test.com")
+
+        assert mock_post.call_args.kwargs["timeout"] == APIClient.REQUEST_TIMEOUT
+
     def test_is_authenticated_false_without_token(self):
         """Test is_authenticated returns False when no token"""
         client = APIClient()

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -123,6 +123,55 @@ class TestLoginScreen:
 
         assert result is True
 
+    def test_password_field_starts_masked(self, screen_manager):
+        """Password field must be masked (password=True) on initial render."""
+        from screens.login import LoginScreen
+
+        screen = LoginScreen(name="login_pw0")
+        screen_manager.add_widget(screen)
+
+        assert screen.password_field.password is True
+        assert screen.eye_btn.icon == "eye"
+
+    def test_toggle_password_visibility_reveals_password(self, screen_manager):
+        """Tapping the eye button must set password=False to reveal the text."""
+        from screens.login import LoginScreen
+
+        screen = LoginScreen(name="login_pw1")
+        screen_manager.add_widget(screen)
+        screen.password_field.text = "secret"
+
+        screen.toggle_password_visibility()
+
+        assert screen.password_field.password is False
+        assert screen.eye_btn.icon == "eye-off"
+
+    def test_toggle_password_visibility_rehides_password(self, screen_manager):
+        """Tapping the eye button a second time must re-mask the password."""
+        from screens.login import LoginScreen
+
+        screen = LoginScreen(name="login_pw2")
+        screen_manager.add_widget(screen)
+        screen.password_field.text = "secret"
+
+        screen.toggle_password_visibility()
+        screen.toggle_password_visibility()
+
+        assert screen.password_field.password is True
+        assert screen.eye_btn.icon == "eye"
+
+    def test_toggle_password_visibility_preserves_text(self, screen_manager):
+        """KivyMD 2.x fix: text must be reassigned to force re-render — value must not be lost."""
+        from screens.login import LoginScreen
+
+        screen = LoginScreen(name="login_pw3")
+        screen_manager.add_widget(screen)
+        screen.password_field.text = "mypassword"
+
+        screen.toggle_password_visibility()
+
+        assert screen.password_field.text == "mypassword"
+
     def test_toggle_mode_switches_to_register(self, screen_manager):
         """Test toggle_mode switches to register mode"""
         from screens.login import LoginScreen

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -1143,3 +1143,82 @@ class TestAnalysisScreen:
                 target()
 
         assert "Failed to generate" in screen.analysis_text.text
+
+    def test_copy_btn_hidden_initially(self, screen_manager):
+        """Copy button must be hidden before any analysis is loaded."""
+        from screens.analysis import AnalysisScreen
+
+        screen = AnalysisScreen(name="analysis_copy1")
+        screen_manager.add_widget(screen)
+
+        assert screen._copy_btn.opacity == 0
+        assert screen._copy_btn.disabled is True
+
+    def test_show_analysis_reveals_copy_btn_and_sets_plain_text(self, screen_manager):
+        """show_analysis() makes the copy button visible and populates _analysis_plain_text."""
+        from screens.analysis import AnalysisScreen
+
+        screen = AnalysisScreen(name="analysis_copy2")
+        screen_manager.add_widget(screen)
+
+        data = {
+            "id": 1,
+            "summary": "Great week",
+            "achievements": {"wins": ["Goal A"]},
+            "improvements": "Sleep earlier",
+            "time_analysis": "Good focus",
+            "habits_analysis": "Consistent",
+            "blind_spots": "None",
+        }
+        screen.show_analysis(data)
+
+        assert screen._copy_btn.opacity == 1
+        assert screen._copy_btn.disabled is False
+        assert "Great week" in screen._analysis_plain_text
+        assert "Sleep earlier" in screen._analysis_plain_text
+
+    def test_show_empty_state_hides_copy_btn(self, screen_manager):
+        """show_empty_state() hides the copy button and clears the plain text."""
+        from screens.analysis import AnalysisScreen
+
+        screen = AnalysisScreen(name="analysis_copy3")
+        screen_manager.add_widget(screen)
+
+        data = {"id": 1, "summary": "Week", "achievements": {}, "improvements": "",
+                "time_analysis": "", "habits_analysis": "", "blind_spots": ""}
+        screen.show_analysis(data)
+        screen.show_empty_state()
+
+        assert screen._copy_btn.opacity == 0
+        assert screen._copy_btn.disabled is True
+        assert screen._analysis_plain_text == ""
+
+    def test_copy_analysis_calls_clipboard(self, screen_manager):
+        """_copy_analysis() passes the full plain text to Clipboard.copy()."""
+        from screens.analysis import AnalysisScreen
+
+        screen = AnalysisScreen(name="analysis_copy4")
+        screen_manager.add_widget(screen)
+
+        data = {"id": 1, "summary": "Summary text", "achievements": {},
+                "improvements": "", "time_analysis": "", "habits_analysis": "", "blind_spots": ""}
+        screen.show_analysis(data)
+
+        with patch("screens.analysis.Clipboard.copy") as mock_copy:
+            with patch("screens.analysis.Clock.schedule_once"):
+                screen._copy_analysis()
+
+        mock_copy.assert_called_once_with(screen._analysis_plain_text)
+        assert "Summary text" in mock_copy.call_args[0][0]
+
+    def test_copy_analysis_does_nothing_when_no_text(self, screen_manager):
+        """_copy_analysis() is a no-op when there is no analysis loaded."""
+        from screens.analysis import AnalysisScreen
+
+        screen = AnalysisScreen(name="analysis_copy5")
+        screen_manager.add_widget(screen)
+
+        with patch("screens.analysis.Clipboard.copy") as mock_copy:
+            screen._copy_analysis()
+
+        mock_copy.assert_not_called()

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -1,5 +1,6 @@
 """Tests for screen modules"""
 
+from time import sleep
 from unittest.mock import patch, MagicMock
 
 
@@ -154,14 +155,34 @@ class TestLoginScreen:
         screen_manager.add_widget(screen)
         screen.password_field.text = "secret"
 
+        # Two distinct taps (real taps are >150 ms apart; sleep past the debounce
+        # window between them so we exercise the re-hide path, not the guard).
         screen.toggle_password_visibility()
+        sleep(0.16)
         screen.toggle_password_visibility()
 
         assert screen.password_field.password is True
         assert screen.eye_btn.icon == "eye"
 
+    def test_toggle_password_visibility_debounces_double_fire(self, screen_manager):
+        """Android fires on_release twice per tap; the second call within the
+        debounce window must be ignored so the field actually toggles."""
+        from screens.login import LoginScreen
+
+        screen = LoginScreen(name="login_pw_debounce")
+        screen_manager.add_widget(screen)
+        screen.password_field.text = "secret"
+
+        # Simulate one physical tap arriving as two rapid events.
+        screen.toggle_password_visibility()
+        screen.toggle_password_visibility()
+
+        # Net effect of one tap: password revealed exactly once, not toggled back.
+        assert screen.password_field.password is False
+        assert screen.eye_btn.icon == "eye-off"
+
     def test_toggle_password_visibility_preserves_text(self, screen_manager):
-        """KivyMD 2.x fix: text must be reassigned to force re-render — value must not be lost."""
+        """Toggling visibility must not lose the entered password text."""
         from screens.login import LoginScreen
 
         screen = LoginScreen(name="login_pw3")

--- a/utils/debounce.py
+++ b/utils/debounce.py
@@ -1,0 +1,37 @@
+"""Debounce helper for UI event handlers.
+
+On Android, a single physical tap dispatches a button's ``on_release`` twice
+(~1 ms apart). For toggles this cancels itself out, and for actions it fires
+duplicate API calls / double navigation. ``@debounce`` collapses repeat calls
+that land within a short window into a single call.
+"""
+
+from functools import wraps
+from time import time
+
+# Two real taps are never closer than this; a double-fire is ~1 ms apart.
+DEFAULT_WAIT = 0.15
+
+
+def debounce(wait: float = DEFAULT_WAIT):
+    """Ignore repeat calls of a bound method within ``wait`` seconds.
+
+    The last-call timestamp is stored per instance and per method name, so
+    different widgets and different handlers don't interfere with each other.
+    Intended for Kivy ``on_release`` / ``on_press`` handlers.
+    """
+
+    def decorator(func):
+        attr = f"_debounce_ts_{func.__name__}"
+
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            now = time()
+            if now - getattr(self, attr, 0.0) < wait:
+                return None
+            setattr(self, attr, now)
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## Summary
Bug fixes and stability improvements for the mobile app, focused on Android touch handling, auth/session resilience, and layout polish.

## Android touch double-fire
- New `utils/debounce.py` with a `@debounce` decorator that collapses the duplicate `on_release` events Android dispatches for a single physical tap (~1 ms apart) into one call.
- Applied to tap handlers across login, home, goals, journal, and analysis screens (navigation, logout, save, delete, generate, add-goal, week nav, password toggle).

## Auth & networking (`services/api_client.py`)
- Store and persist the **refresh token**; add `_refresh_access_token()` that  swaps a refresh token for a new access token on a 401, serialised with a lock so concurrent background requests don't race. A rejected refresh token logs  out and falls back to the login screen.
- New central `_request()` helper: default timeouts, one automatic retry after a token refresh on 401, and `allow_statuses` so 404s map cleanly to `None`/`[]`. All endpoints refactored onto it.
- Add request timeouts (15 s default; 120 s for analysis generation).
- `update_goal` now uses PATCH instead of PUT.

## Login screen
- Fix the password-visibility eye toggle: debounced against the double-fire and forces a field repaint (`_refresh_text`), since KivyMD 2.x doesn't re-render when `password` flips at runtime; the icon updates first for instant feedback.
- Fixed-height password row and sized eye button.

## UI / layout polish
- `home.py`: resized StatCard/NavCard proportions (taller nav cards, logout spacing) to stop text clipping.
- `analysis.py`: add a "copy analysis" button that assembles the full analysis  as plain text and copies it, with check-icon feedback.
- `main.py`: window sizing + min size, disable multitouch, **Android hardware back button** returns to home instead of exiting, debounced resize relayout, and `softinput_mode` for the keyboard.

## Tooling, tests, docs
- `ruff.toml`: ignore E402 in `main.py` (Kivy requires `Config.set()` before other kivy imports).
- New tests in `tests/test_api_client.py` and `tests/test_screens.py` covering the refresh flow, timeouts, and debounce behavior.
- `CLAUDE.md` updated.

## Commits
- solving bugs
- solved some bugs
- deleting code
- minor time fix in log in
- Fix Android touch bugs: eye toggle + global on_release double-fire
- ready for reviewer
