### PR TITLE
Per-week goals + goal editing

### DIFF
--- a/screens/analysis.py
+++ b/screens/analysis.py
@@ -21,6 +21,7 @@ from kivymd.uix.scrollview import MDScrollView
 
 from services.api_client import api_client
 from utils.debounce import debounce
+from utils.week import monday_of, week_range_text
 
 
 BLUE = (0.129, 0.588, 0.953, 1)
@@ -55,16 +56,12 @@ _SECTIONS = [
 ]
 
 
-def _monday_of(d: date) -> date:
-    return d - timedelta(days=d.weekday())
-
-
 class AnalysisScreen(MDScreen):
     """Screen for viewing weekly AI analysis"""
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._current_week_start = _monday_of(date.today())
+        self._current_week_start = monday_of(date.today())
         self._section_cards = {}
         self._section_labels = {}
         self._dialog = None
@@ -297,10 +294,7 @@ class AnalysisScreen(MDScreen):
     # --- Week navigation ---
 
     def _week_text(self) -> str:
-        end = self._current_week_start + timedelta(days=6)
-        s = self._current_week_start.strftime('%b %d').replace(' 0', ' ')
-        e = end.strftime('%b %d, %Y').replace(' 0', ' ')
-        return f"{s} – {e}"
+        return week_range_text(self._current_week_start)
 
     @debounce()
     def _change_week(self, delta: int):

--- a/screens/goals.py
+++ b/screens/goals.py
@@ -305,9 +305,14 @@ class GoalsScreen(MDScreen):
                 )
             except Exception as e:
                 msg = str(e)
-                Clock.schedule_once(lambda dt: self.show_error(msg))
+                Clock.schedule_once(lambda dt: self._on_load_error(msg))
 
         threading.Thread(target=_do, daemon=True).start()
+
+    def _on_load_error(self, message: str):
+        """Handle a failed week load: re-enable navigation, then show the error."""
+        self._set_nav_enabled(True)
+        self.show_error(message)
 
     def _week_text(self) -> str:
         """Human-readable range for the selected week (e.g. 'Jul 14 – Jul 20, 2026')."""
@@ -431,9 +436,13 @@ class GoalsScreen(MDScreen):
         self._refresh_empty_state()
 
     def show_error(self, message: str):
-        """Display an error message in the status label and re-enable navigation."""
+        """Display an error message in the status label.
+
+        Does not touch week navigation: a failing goal action (toggle/delete/
+        edit/create) must not re-enable the arrows while a week load still has
+        them disabled. The load-error path handles that via _on_load_error.
+        """
         self.status_label.text = message
-        self._set_nav_enabled(True)
 
     def _open_goal_dialog(self, headline: str, initial: str, confirm_label: str, confirm_callback):
         """Open a goal text dialog shared by the add and edit flows."""
@@ -495,12 +504,24 @@ class GoalsScreen(MDScreen):
             try:
                 result = api_client.create_goal(text, week_start_date=week_start_str)
                 goal_id = result.get("id")
-                Clock.schedule_once(lambda dt: self._add_goal_card(text, goal_id=goal_id))
+                Clock.schedule_once(
+                    lambda dt: self._add_created_goal(text, goal_id, week_start_str)
+                )
             except Exception as e:
                 msg = str(e)
                 Clock.schedule_once(lambda dt: self.show_error(msg))
 
         threading.Thread(target=_do, daemon=True).start()
+
+    def _add_created_goal(self, text: str, goal_id, week_start_str: str):
+        """Render a newly created goal, but only if its week is still on screen.
+
+        If the user navigated to another week while the create was in flight,
+        the card would otherwise be appended under the wrong week's list.
+        """
+        if week_start_str != self._current_week_start.isoformat():
+            return
+        self._add_goal_card(text, goal_id=goal_id)
 
     @debounce()
     def confirm_edit_goal(self, *args):

--- a/screens/goals.py
+++ b/screens/goals.py
@@ -1,6 +1,7 @@
 """Goals Screen - Issue #5/#6: Weekly Goals Screen UI + API Integration"""
 
 import threading
+from datetime import date, timedelta
 
 from kivy.clock import Clock
 from kivymd.uix.screen import MDScreen
@@ -28,17 +29,23 @@ WHITE_DIM = (1, 1, 1, 0.85)
 BG = (0.96, 0.96, 0.96, 1)
 
 
+def _monday_of(d: date) -> date:
+    """Return the Monday of the week containing ``d``."""
+    return d - timedelta(days=d.weekday())
+
+
 class GoalCard(MDCard):
     """Card representing a single goal with checkbox and delete button"""
 
-    def __init__(self, goal_text: str, goal_id, on_delete, on_toggle, completed: bool = False, **kwargs):
-        """Build the card with checkbox, label, and delete button.
+    def __init__(self, goal_text: str, goal_id, on_delete, on_toggle, on_edit=None, completed: bool = False, **kwargs):
+        """Build the card with checkbox, label, edit button, and delete button.
 
         Args:
             goal_text: Text to display for the goal.
             goal_id: Backend ID used for API calls, or None for local-only cards.
             on_delete: Callback(card) invoked when the trash button is tapped.
             on_toggle: Callback(card, completed) invoked when the checkbox changes.
+            on_edit: Callback(card) invoked when the pencil button is tapped.
             completed: Initial checked state.
         """
         super().__init__(
@@ -52,8 +59,10 @@ class GoalCard(MDCard):
             **kwargs,
         )
         self.goal_id = goal_id
+        self.goal_text = goal_text
         self._on_delete = on_delete
         self._on_toggle = on_toggle
+        self._on_edit = on_edit
 
         self.checkbox = MDCheckbox(
             size_hint=(None, None),
@@ -74,6 +83,17 @@ class GoalCard(MDCard):
         )
         self.add_widget(self.goal_label)
 
+        self.edit_btn = MDIconButton(
+            icon="pencil-outline",
+            theme_icon_color="Custom",
+            icon_color=BLUE,
+            size_hint=(None, None),
+            size=(40, 40),
+            pos_hint={"center_y": 0.5},
+            on_release=self._handle_edit,
+        )
+        self.add_widget(self.edit_btn)
+
         self.delete_btn = MDIconButton(
             icon="trash-can-outline",
             theme_icon_color="Custom",
@@ -90,9 +110,24 @@ class GoalCard(MDCard):
         """Invoke the delete callback, debounced against Android's double on_release."""
         self._on_delete(self)
 
+    @debounce()
+    def _handle_edit(self, *args):
+        """Invoke the edit callback, debounced against Android's double on_release."""
+        if self._on_edit:
+            self._on_edit(self)
+
+    def set_text(self, text: str):
+        """Update the goal's displayed text and stored value."""
+        self.goal_text = text
+        self.goal_label.text = text
+
     def on_touch_down(self, touch):
-        """Toggle checkbox when the card body is tapped (excluding the delete button)."""
-        if self.collide_point(*touch.pos) and not self.delete_btn.collide_point(*touch.pos):
+        """Toggle checkbox when the card body is tapped (excluding action buttons)."""
+        if (
+            self.collide_point(*touch.pos)
+            and not self.delete_btn.collide_point(*touch.pos)
+            and not self.edit_btn.collide_point(*touch.pos)
+        ):
             self.checkbox.active = not self.checkbox.active
             return True
         return super().on_touch_down(touch)
@@ -110,6 +145,8 @@ class GoalsScreen(MDScreen):
         """Initialise state and build the UI."""
         super().__init__(**kwargs)
         self._dialog = None
+        self._current_week_start = _monday_of(date.today())
+        self._editing_card = None
         self.build_ui()
 
     def build_ui(self):
@@ -143,7 +180,7 @@ class GoalsScreen(MDScreen):
         ))
         header.add_widget(top_row)
         header.add_widget(MDLabel(
-            text="This week's targets",
+            text="Your weekly targets",
             font_style="Body",
             role="medium",
             theme_text_color="Custom",
@@ -151,6 +188,41 @@ class GoalsScreen(MDScreen):
             adaptive_height=True,
         ))
         root.add_widget(header)
+
+        # --- Week selector (blue strip) ---
+        week_row = MDBoxLayout(
+            orientation="horizontal",
+            size_hint=(1, None),
+            height=48,
+            padding=[4, 0, 4, 0],
+            md_bg_color=BLUE,
+        )
+        self._prev_btn = MDIconButton(
+            icon="chevron-left",
+            theme_icon_color="Custom",
+            icon_color=WHITE,
+            on_release=lambda _: self._change_week(-1),
+        )
+        self.week_label = MDLabel(
+            text=self._week_text(),
+            font_style="Body",
+            role="medium",
+            theme_text_color="Custom",
+            text_color=WHITE,
+            halign="center",
+            adaptive_height=True,
+            pos_hint={"center_y": 0.5},
+        )
+        self._next_btn = MDIconButton(
+            icon="chevron-right",
+            theme_icon_color="Custom",
+            icon_color=WHITE,
+            on_release=lambda _: self._change_week(1),
+        )
+        week_row.add_widget(self._prev_btn)
+        week_row.add_widget(self.week_label)
+        week_row.add_widget(self._next_btn)
+        root.add_widget(week_row)
 
         # --- Content ---
         content_bg = MDBoxLayout(orientation="vertical", md_bg_color=BG)
@@ -217,18 +289,33 @@ class GoalsScreen(MDScreen):
         self.load_goals()
 
     def load_goals(self):
-        """Fetch goals from the API and populate the list."""
+        """Fetch goals for the selected week from the API and populate the list."""
         self.status_label.text = "Loading..."
+        week_start_str = self._current_week_start.isoformat()
 
         def _do():
             try:
-                goals = api_client.get_goals()
+                goals = api_client.get_goals(week_start_str)
                 Clock.schedule_once(lambda dt: self._populate_goals(goals))
             except Exception as e:
                 msg = str(e)
                 Clock.schedule_once(lambda dt: self.show_error(msg))
 
         threading.Thread(target=_do, daemon=True).start()
+
+    def _week_text(self) -> str:
+        """Human-readable range for the selected week (e.g. 'Jul 14 – Jul 20, 2026')."""
+        end = self._current_week_start + timedelta(days=6)
+        s = self._current_week_start.strftime('%b %d').replace(' 0', ' ')
+        e = end.strftime('%b %d, %Y').replace(' 0', ' ')
+        return f"{s} – {e}"
+
+    @debounce()
+    def _change_week(self, delta: int):
+        """Move the selected week by ``delta`` weeks and reload its goals."""
+        self._current_week_start += timedelta(weeks=delta)
+        self.week_label.text = self._week_text()
+        self.load_goals()
 
     def _populate_goals(self, goals):
         """Clear existing cards and render goals from API data."""
@@ -249,6 +336,7 @@ class GoalsScreen(MDScreen):
             goal_id=goal_id,
             on_delete=self.delete_goal,
             on_toggle=self.toggle_goal,
+            on_edit=self.show_edit_dialog,
             completed=completed,
         )
         self.goals_list.add_widget(card)
@@ -298,34 +386,46 @@ class GoalsScreen(MDScreen):
         """Display an error message in the status label."""
         self.status_label.text = message
 
-    @debounce()
-    def show_add_dialog(self):
-        """Open the dialog for entering a new goal."""
-        self.new_goal_field = MDTextField(
+    def _open_goal_dialog(self, headline: str, initial: str, confirm_label: str, confirm_callback):
+        """Open a goal text dialog shared by the add and edit flows."""
+        self._goal_field = MDTextField(
             mode="outlined",
             hint_text="Describe your goal...",
+            text=initial,
             size_hint_x=1,
         )
 
         cancel_btn = MDButton(style="text", on_release=self.close_dialog)
         cancel_btn.add_widget(MDButtonText(text="Cancel"))
 
-        add_btn = MDButton(style="text", on_release=self.confirm_add_goal)
-        add_btn.add_widget(MDButtonText(text="Add"))
+        confirm_btn = MDButton(style="text", on_release=confirm_callback)
+        confirm_btn.add_widget(MDButtonText(text=confirm_label))
 
         self._dialog = MDDialog(
-            MDDialogHeadlineText(text="New Goal"),
+            MDDialogHeadlineText(text=headline),
             MDDialogContentContainer(
-                self.new_goal_field,
+                self._goal_field,
                 orientation="vertical",
             ),
             MDDialogButtonContainer(
                 cancel_btn,
-                add_btn,
+                confirm_btn,
             ),
         )
         self._dialog.open()
-        Clock.schedule_once(lambda dt: setattr(self.new_goal_field, "focus", True), 0.1)
+        Clock.schedule_once(lambda dt: setattr(self._goal_field, "focus", True), 0.1)
+
+    @debounce()
+    def show_add_dialog(self):
+        """Open the dialog for entering a new goal."""
+        self._editing_card = None
+        self._open_goal_dialog("New Goal", "", "Add", self.confirm_add_goal)
+
+    @debounce()
+    def show_edit_dialog(self, card: "GoalCard"):
+        """Open the dialog for editing an existing goal's text."""
+        self._editing_card = card
+        self._open_goal_dialog("Edit Goal", card.goal_text, "Save", self.confirm_edit_goal)
 
     def close_dialog(self, *args):
         """Dismiss the active dialog and clear the reference."""
@@ -335,17 +435,42 @@ class GoalsScreen(MDScreen):
 
     @debounce()
     def confirm_add_goal(self, *args):
-        """Read the dialog input, close it, and create the goal via API."""
-        text = self.new_goal_field.text.strip()
+        """Read the dialog input, close it, and create the goal for the selected week."""
+        text = self._goal_field.text.strip()
         self.close_dialog()
         if not text:
+            return
+        week_start_str = self._current_week_start.isoformat()
+
+        def _do():
+            try:
+                result = api_client.create_goal(text, week_start_date=week_start_str)
+                goal_id = result.get("id")
+                Clock.schedule_once(lambda dt: self._add_goal_card(text, goal_id=goal_id))
+            except Exception as e:
+                msg = str(e)
+                Clock.schedule_once(lambda dt: self.show_error(msg))
+
+        threading.Thread(target=_do, daemon=True).start()
+
+    @debounce()
+    def confirm_edit_goal(self, *args):
+        """Read the dialog input, close it, and persist the goal's new text."""
+        card = self._editing_card
+        text = self._goal_field.text.strip()
+        self.close_dialog()
+        if card is None or not text or text == card.goal_text:
+            return
+
+        # Local-only card (not yet persisted): just update its text.
+        if card.goal_id is None:
+            card.set_text(text)
             return
 
         def _do():
             try:
-                result = api_client.create_goal(text)
-                goal_id = result.get("id")
-                Clock.schedule_once(lambda dt: self._add_goal_card(text, goal_id=goal_id))
+                api_client.update_goal(card.goal_id, goal_text=text)
+                Clock.schedule_once(lambda dt: card.set_text(text))
             except Exception as e:
                 msg = str(e)
                 Clock.schedule_once(lambda dt: self.show_error(msg))

--- a/screens/goals.py
+++ b/screens/goals.py
@@ -21,17 +21,13 @@ from kivymd.uix.textfield import MDTextField
 
 from services.api_client import api_client
 from utils.debounce import debounce
+from utils.week import monday_of, week_range_text
 
 
 BLUE = (0.129, 0.588, 0.953, 1)
 WHITE = (1, 1, 1, 1)
 WHITE_DIM = (1, 1, 1, 0.85)
 BG = (0.96, 0.96, 0.96, 1)
-
-
-def _monday_of(d: date) -> date:
-    """Return the Monday of the week containing ``d``."""
-    return d - timedelta(days=d.weekday())
 
 
 class GoalCard(MDCard):
@@ -145,7 +141,7 @@ class GoalsScreen(MDScreen):
         """Initialise state and build the UI."""
         super().__init__(**kwargs)
         self._dialog = None
-        self._current_week_start = _monday_of(date.today())
+        self._current_week_start = monday_of(date.today())
         self._editing_card = None
         self.build_ui()
 
@@ -201,7 +197,7 @@ class GoalsScreen(MDScreen):
             icon="chevron-left",
             theme_icon_color="Custom",
             icon_color=WHITE,
-            on_release=lambda _: self._change_week(-1),
+            on_release=self._week_prev,
         )
         self.week_label = MDLabel(
             text=self._week_text(),
@@ -217,7 +213,7 @@ class GoalsScreen(MDScreen):
             icon="chevron-right",
             theme_icon_color="Custom",
             icon_color=WHITE,
-            on_release=lambda _: self._change_week(1),
+            on_release=self._week_next,
         )
         week_row.add_widget(self._prev_btn)
         week_row.add_widget(self.week_label)
@@ -285,18 +281,28 @@ class GoalsScreen(MDScreen):
         self._refresh_empty_state()
 
     def on_pre_enter(self):
-        """Reload goals from the API each time the screen is shown."""
+        """Reset to the current week and reload its goals each time the screen is shown.
+
+        Resetting avoids silently adding goals to a past/future week the user had
+        navigated to on a previous visit, and keeps "current week" correct if the
+        app has been open across a week boundary.
+        """
+        self._current_week_start = monday_of(date.today())
+        self.week_label.text = self._week_text()
         self.load_goals()
 
     def load_goals(self):
         """Fetch goals for the selected week from the API and populate the list."""
         self.status_label.text = "Loading..."
+        self._set_nav_enabled(False)
         week_start_str = self._current_week_start.isoformat()
 
         def _do():
             try:
                 goals = api_client.get_goals(week_start_str)
-                Clock.schedule_once(lambda dt: self._populate_goals(goals))
+                Clock.schedule_once(
+                    lambda dt: self._populate_goals(goals, week_start_str)
+                )
             except Exception as e:
                 msg = str(e)
                 Clock.schedule_once(lambda dt: self.show_error(msg))
@@ -305,21 +311,50 @@ class GoalsScreen(MDScreen):
 
     def _week_text(self) -> str:
         """Human-readable range for the selected week (e.g. 'Jul 14 – Jul 20, 2026')."""
-        end = self._current_week_start + timedelta(days=6)
-        s = self._current_week_start.strftime('%b %d').replace(' 0', ' ')
-        e = end.strftime('%b %d, %Y').replace(' 0', ' ')
-        return f"{s} – {e}"
+        return week_range_text(self._current_week_start)
+
+    def _set_nav_enabled(self, enabled: bool):
+        """Enable/disable the week arrows (disabled while a week is loading).
+
+        Serialising loads this way prevents overlapping fetches whose responses
+        could arrive out of order and render the wrong week's goals.
+        """
+        self._prev_btn.disabled = not enabled
+        self._next_btn.disabled = not enabled
 
     @debounce()
+    def _week_prev(self, *args):
+        """Go to the previous week. Debounced per-direction (see _week_next)."""
+        self._change_week(-1)
+
+    @debounce()
+    def _week_next(self, *args):
+        """Go to the next week.
+
+        Prev/next are separate debounced methods so a quick ◀ then ▶ isn't
+        collapsed into one — only genuine same-button double-fires are.
+        """
+        self._change_week(1)
+
     def _change_week(self, delta: int):
         """Move the selected week by ``delta`` weeks and reload its goals."""
         self._current_week_start += timedelta(weeks=delta)
         self.week_label.text = self._week_text()
         self.load_goals()
 
-    def _populate_goals(self, goals):
-        """Clear existing cards and render goals from API data."""
-        for card in [w for w in self.goals_list.children if isinstance(w, GoalCard)]:
+    def _populate_goals(self, goals, week_start_str=None):
+        """Clear existing cards and render goals from API data.
+
+        ``week_start_str`` is the week the fetch was issued for; if the user has
+        since navigated to a different week, this (now stale) response is dropped.
+        """
+        if (
+            week_start_str is not None
+            and week_start_str != self._current_week_start.isoformat()
+        ):
+            return
+        self._set_nav_enabled(True)
+        for card in self._goal_cards():
             self.goals_list.remove_widget(card)
         self.status_label.text = ""
         for goal in goals:
@@ -327,10 +362,19 @@ class GoalsScreen(MDScreen):
                 goal_text=goal.get("goal_text", ""),
                 goal_id=goal.get("id"),
                 completed=goal.get("completed", False),
+                refresh=False,
             )
+        # Refresh once for the whole batch rather than per card.
+        self._refresh_empty_state()
 
-    def _add_goal_card(self, goal_text: str, goal_id=None, completed: bool = False):
-        """Create a GoalCard and append it to the list."""
+    def _add_goal_card(
+        self, goal_text: str, goal_id=None, completed: bool = False, refresh: bool = True
+    ):
+        """Create a GoalCard and append it to the list.
+
+        ``refresh`` lets bulk callers skip the per-card empty-state refresh and
+        do it once at the end.
+        """
         card = GoalCard(
             goal_text=goal_text,
             goal_id=goal_id,
@@ -340,12 +384,16 @@ class GoalsScreen(MDScreen):
             completed=completed,
         )
         self.goals_list.add_widget(card)
-        self._refresh_empty_state()
+        if refresh:
+            self._refresh_empty_state()
+
+    def _goal_cards(self):
+        """The GoalCard widgets currently in the list."""
+        return [w for w in self.goals_list.children if isinstance(w, GoalCard)]
 
     def _refresh_empty_state(self):
         """Show empty label only when there are no goal cards."""
-        goal_cards = [w for w in self.goals_list.children if isinstance(w, GoalCard)]
-        self.empty_label.opacity = 0 if goal_cards else 1
+        self.empty_label.opacity = 0 if self._goal_cards() else 1
 
     def toggle_goal(self, card: "GoalCard", completed: bool):
         """Persist completed state to the API."""
@@ -383,8 +431,9 @@ class GoalsScreen(MDScreen):
         self._refresh_empty_state()
 
     def show_error(self, message: str):
-        """Display an error message in the status label."""
+        """Display an error message in the status label and re-enable navigation."""
         self.status_label.text = message
+        self._set_nav_enabled(True)
 
     def _open_goal_dialog(self, headline: str, initial: str, confirm_label: str, confirm_callback):
         """Open a goal text dialog shared by the add and edit flows."""

--- a/screens/home.py
+++ b/screens/home.py
@@ -295,7 +295,11 @@ class HomeScreen(MDScreen):
             goals_value = "—"
             journal_value = "—"
             try:
-                goals = api_client.get_goals()
+                today = datetime.date.today()
+                week_start = (
+                    today - datetime.timedelta(days=today.weekday())
+                ).isoformat()
+                goals = api_client.get_goals(week_start)
                 completed = sum(1 for g in goals if g.get("completed"))
                 goals_value = f"{completed}/{len(goals)}"
             except Exception:

--- a/screens/home.py
+++ b/screens/home.py
@@ -14,6 +14,7 @@ from kivymd.icon_definitions import md_icons
 
 from services.api_client import api_client
 from utils.debounce import debounce
+from utils.week import monday_of
 
 
 BLUE = (0.129, 0.588, 0.953, 1)
@@ -295,10 +296,7 @@ class HomeScreen(MDScreen):
             goals_value = "—"
             journal_value = "—"
             try:
-                today = datetime.date.today()
-                week_start = (
-                    today - datetime.timedelta(days=today.weekday())
-                ).isoformat()
+                week_start = monday_of(datetime.date.today()).isoformat()
                 goals = api_client.get_goals(week_start)
                 completed = sum(1 for g in goals if g.get("completed"))
                 goals_value = f"{completed}/{len(goals)}"

--- a/services/api_client.py
+++ b/services/api_client.py
@@ -22,8 +22,10 @@ TOKEN_FILE = os.path.join(_token_dir, ".coach_assistant_token.json")
 class APIClient:
     """Handles all API communication with the backend"""
 
-    # For phone testing: change to your laptop's local IP, e.g. http://192.168.1.x:8000/api
-    API_BASE_URL = "http://localhost:8000/api"
+    # Defaults to localhost for desktop dev. To test against a backend on
+    # another machine (e.g. from a phone or a second laptop), set COACH_API_URL
+    # to that machine's LAN address, e.g. http://192.168.1.53:8000/api
+    API_BASE_URL = os.getenv("COACH_API_URL", "http://localhost:8000/api")
 
     REQUEST_TIMEOUT = 15  # seconds
 

--- a/services/api_client.py
+++ b/services/api_client.py
@@ -5,9 +5,11 @@ API Client for communicating with Django backend
 import os
 import json
 import threading
-from datetime import date, timedelta
+from datetime import date
 import requests
 from typing import Optional, Dict, List
+
+from utils.week import monday_of
 
 # On Android (p4a), expanduser("~") resolves to /data which is not writable.
 # Fall back to the app's internal files directory (parent of the working dir).
@@ -216,8 +218,7 @@ class APIClient:
                 the Monday of the current week when omitted.
         """
         if week_start_date is None:
-            today = date.today()
-            week_start_date = (today - timedelta(days=today.weekday())).isoformat()
+            week_start_date = monday_of(date.today()).isoformat()
         data = {
             "goal_text": goal_text,
             "category": category,

--- a/services/api_client.py
+++ b/services/api_client.py
@@ -22,10 +22,11 @@ TOKEN_FILE = os.path.join(_token_dir, ".coach_assistant_token.json")
 class APIClient:
     """Handles all API communication with the backend"""
 
-    # Defaults to localhost for desktop dev. To test against a backend on
-    # another machine (e.g. from a phone or a second laptop), set COACH_API_URL
-    # to that machine's LAN address, e.g. http://192.168.1.53:8000/api
-    API_BASE_URL = os.getenv("COACH_API_URL", "http://localhost:8000/api")
+    # Defaults to the backend's LAN address so any device on the same
+    # network works without per-machine setup. Pin this IP with a DHCP
+    # reservation on the router so it doesn't change. Override per-machine
+    # (e.g. localhost for dev on the server itself) via COACH_API_URL.
+    API_BASE_URL = os.getenv("COACH_API_URL", "http://192.168.1.53:8000/api")
 
     REQUEST_TIMEOUT = 15  # seconds
 

--- a/services/api_client.py
+++ b/services/api_client.py
@@ -22,11 +22,12 @@ TOKEN_FILE = os.path.join(_token_dir, ".coach_assistant_token.json")
 class APIClient:
     """Handles all API communication with the backend"""
 
-    # Defaults to the backend's LAN address so any device on the same
-    # network works without per-machine setup. Pin this IP with a DHCP
-    # reservation on the router so it doesn't change. Override per-machine
-    # (e.g. localhost for dev on the server itself) via COACH_API_URL.
-    API_BASE_URL = os.getenv("COACH_API_URL", "http://192.168.1.53:8000/api")
+    # Defaults to the backend's mDNS (.local) name, which resolves on the LAN
+    # via Bonjour/Avahi to whatever IP the server currently has — so any device
+    # on the same network works with no per-machine setup and no IP hardcoded.
+    # Override per-machine (e.g. localhost for dev on the server itself) via
+    # the COACH_API_URL env var.
+    API_BASE_URL = os.getenv("COACH_API_URL", "http://coach-backend.local:8000/api")
 
     REQUEST_TIMEOUT = 15  # seconds
 

--- a/services/api_client.py
+++ b/services/api_client.py
@@ -190,18 +190,38 @@ class APIClient:
         return bool(self.token)
 
     # Goals endpoints
-    def get_goals(self) -> List[Dict]:
-        """Get all goals for current week"""
-        return self._request("get", f"{self.API_BASE_URL}/goals/").json()
+    def get_goals(self, week_start_date: Optional[str] = None) -> List[Dict]:
+        """Get goals, optionally scoped to a single week.
 
-    def create_goal(self, goal_text: str, category: str = "personal") -> Dict:
-        """Create new weekly goal for the current week."""
-        today = date.today()
-        week_start = today - timedelta(days=today.weekday())
+        Args:
+            week_start_date: Monday of the week (YYYY-MM-DD). When provided, the
+                backend filters to that week; when omitted, it returns all of the
+                user's goals across every week.
+        """
+        params = {"week_start_date": week_start_date} if week_start_date else None
+        return self._request(
+            "get", f"{self.API_BASE_URL}/goals/", params=params
+        ).json()
+
+    def create_goal(
+        self,
+        goal_text: str,
+        category: str = "personal",
+        week_start_date: Optional[str] = None,
+    ) -> Dict:
+        """Create a new weekly goal.
+
+        Args:
+            week_start_date: Monday of the target week (YYYY-MM-DD). Defaults to
+                the Monday of the current week when omitted.
+        """
+        if week_start_date is None:
+            today = date.today()
+            week_start_date = (today - timedelta(days=today.weekday())).isoformat()
         data = {
             "goal_text": goal_text,
             "category": category,
-            "week_start_date": week_start.isoformat(),
+            "week_start_date": week_start_date,
         }
         return self._request("post", f"{self.API_BASE_URL}/goals/", json=data).json()
 

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -201,6 +201,45 @@ class TestAPIClient:
         expected_monday = (today - timedelta(days=today.weekday())).isoformat()
         assert payload["week_start_date"] == expected_monday
 
+    @patch("services.api_client.requests.get")
+    def test_get_goals_passes_week_filter(self, mock_get):
+        """get_goals(week) sends ?week_start_date as a query param."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        client = APIClient()
+        client.get_goals("2026-07-13")
+
+        assert mock_get.call_args[1]["params"] == {"week_start_date": "2026-07-13"}
+
+    @patch("services.api_client.requests.get")
+    def test_get_goals_without_week_sends_no_filter(self, mock_get):
+        """get_goals() with no week sends params=None (all goals)."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        client = APIClient()
+        client.get_goals()
+
+        assert mock_get.call_args[1]["params"] is None
+
+    @patch("services.api_client.requests.post")
+    def test_create_goal_uses_provided_week(self, mock_post):
+        """create_goal(week_start_date=...) uses the given week, not the current one."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": 1}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        client = APIClient()
+        client.create_goal("Test goal", week_start_date="2026-07-13")
+
+        assert mock_post.call_args[1]["json"]["week_start_date"] == "2026-07-13"
+
     @patch("services.api_client.requests.patch")
     def test_update_goal_uses_patch(self, mock_patch):
         """update_goal must use PATCH (not PUT) — PUT returns 400 Bad Request."""

--- a/tests/test_buildozer.py
+++ b/tests/test_buildozer.py
@@ -210,8 +210,12 @@ class TestAPIClientAndroidCompat:
     def test_api_base_url_not_hardcoded_to_localhost_only(self):
         """Warn if URL is still localhost — it won't work on a physical device."""
         source = self._read_client()
-        # Extract the actual value on the API_BASE_URL assignment line
-        match = re.search(r'API_BASE_URL\s*=\s*["\']([^"\']+)["\']', source)
+        # Extract the value on the API_BASE_URL assignment line. It may be a
+        # plain string or an os.getenv(...) call whose default is a string.
+        match = re.search(
+            r'API_BASE_URL\s*=\s*(?:os\.getenv\([^,]+,\s*)?["\']([^"\']+)["\']',
+            source,
+        )
         assert match, "Could not parse API_BASE_URL value"
         url = match.group(1)
         # It's fine for localhost during desktop dev, but flag it as a reminder

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -490,7 +490,7 @@ class TestGoalsScreen:
         screen_manager.add_widget(screen)
 
         cards_before = [w for w in screen.goals_list.children if isinstance(w, GoalCard)]
-        screen.new_goal_field = MDTextField(text="   ")
+        screen._goal_field = MDTextField(text="   ")
         screen._dialog = MagicMock()
 
         with patch("screens.goals.threading.Thread") as mock_thread:
@@ -508,7 +508,7 @@ class TestGoalsScreen:
         screen = GoalsScreen(name="goals")
         screen_manager.add_widget(screen)
 
-        screen.new_goal_field = MDTextField(text="Walk 10k steps")
+        screen._goal_field = MDTextField(text="Walk 10k steps")
         screen._dialog = MagicMock()
 
         with patch("screens.goals.threading.Thread") as mock_thread:
@@ -611,6 +611,108 @@ class TestGoalsScreen:
 
         screen.show_error("Network error")
         assert screen.status_label.text == "Network error"
+
+    def test_confirm_add_goal_uses_selected_week(self, screen_manager):
+        """confirm_add_goal creates the goal for the currently selected week."""
+        from datetime import date
+        from screens.goals import GoalsScreen
+        from kivymd.uix.textfield import MDTextField
+
+        screen = GoalsScreen(name="goals")
+        screen_manager.add_widget(screen)
+        screen._current_week_start = date(2026, 7, 13)  # a Monday
+        screen._goal_field = MDTextField(text="Plan the week")
+        screen._dialog = MagicMock()
+
+        with patch("services.api_client.api_client.create_goal") as mock_create, \
+             patch("screens.goals.threading.Thread") as mock_thread:
+            # Run the worker synchronously so we can assert the API call.
+            mock_thread.side_effect = lambda target, daemon=None: MagicMock(
+                start=target
+            )
+            mock_create.return_value = {"id": 99}
+            screen.confirm_add_goal()
+
+        mock_create.assert_called_once_with(
+            "Plan the week", week_start_date="2026-07-13"
+        )
+
+    def test_change_week_reloads_goals(self, screen_manager):
+        """_change_week shifts the week by 7 days and reloads."""
+        from datetime import date
+        from screens.goals import GoalsScreen
+
+        screen = GoalsScreen(name="goals")
+        screen_manager.add_widget(screen)
+        screen._current_week_start = date(2026, 7, 13)
+
+        with patch.object(screen, "load_goals") as mock_load:
+            screen._change_week(1)
+            assert screen._current_week_start == date(2026, 7, 20)
+            mock_load.assert_called_once()
+
+    def test_edit_goal_persists_new_text(self, screen_manager):
+        """confirm_edit_goal PATCHes goal_text and updates the card label."""
+        from screens.goals import GoalsScreen, GoalCard
+        from kivymd.uix.textfield import MDTextField
+
+        screen = GoalsScreen(name="goals")
+        screen_manager.add_widget(screen)
+        screen._add_goal_card("Old text", goal_id=5)
+        card = next(w for w in screen.goals_list.children if isinstance(w, GoalCard))
+
+        screen._editing_card = card
+        screen._goal_field = MDTextField(text="New text")
+        screen._dialog = MagicMock()
+
+        with patch("services.api_client.api_client.update_goal") as mock_update, \
+             patch("screens.goals.Clock.schedule_once", side_effect=lambda fn, *a: fn(0)), \
+             patch("screens.goals.threading.Thread") as mock_thread:
+            mock_thread.side_effect = lambda target, daemon=None: MagicMock(
+                start=target
+            )
+            screen.confirm_edit_goal()
+
+        mock_update.assert_called_once_with(5, goal_text="New text")
+        assert card.goal_text == "New text"
+
+    def test_edit_goal_ignores_unchanged_text(self, screen_manager):
+        """confirm_edit_goal does nothing when the text is unchanged."""
+        from screens.goals import GoalsScreen, GoalCard
+        from kivymd.uix.textfield import MDTextField
+
+        screen = GoalsScreen(name="goals")
+        screen_manager.add_widget(screen)
+        screen._add_goal_card("Same text", goal_id=5)
+        card = next(w for w in screen.goals_list.children if isinstance(w, GoalCard))
+
+        screen._editing_card = card
+        screen._goal_field = MDTextField(text="Same text")
+        screen._dialog = MagicMock()
+
+        with patch("screens.goals.threading.Thread") as mock_thread:
+            screen.confirm_edit_goal()
+            mock_thread.assert_not_called()
+
+    def test_edit_goal_local_card_updates_without_api(self, screen_manager):
+        """Editing a not-yet-persisted card updates text without an API call."""
+        from screens.goals import GoalsScreen, GoalCard
+        from kivymd.uix.textfield import MDTextField
+
+        screen = GoalsScreen(name="goals")
+        screen_manager.add_widget(screen)
+        screen._add_goal_card("Local")  # no goal_id
+        card = next(w for w in screen.goals_list.children if isinstance(w, GoalCard))
+
+        screen._editing_card = card
+        screen._goal_field = MDTextField(text="Local edited")
+        screen._dialog = MagicMock()
+
+        with patch("screens.goals.threading.Thread") as mock_thread:
+            screen.confirm_edit_goal()
+            mock_thread.assert_not_called()
+
+        assert card.goal_text == "Local edited"
 
 
 class TestJournalScreen:

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -612,6 +612,33 @@ class TestGoalsScreen:
         screen.show_error("Network error")
         assert screen.status_label.text == "Network error"
 
+    def test_on_load_error_reenables_nav(self, screen_manager):
+        """A failed week load re-enables the arrows and shows the message."""
+        from screens.goals import GoalsScreen
+
+        screen = GoalsScreen(name="goals")
+        screen_manager.add_widget(screen)
+        screen._set_nav_enabled(False)  # load in flight
+
+        screen._on_load_error("boom")
+
+        assert screen._prev_btn.disabled is False
+        assert screen._next_btn.disabled is False
+        assert screen.status_label.text == "boom"
+
+    def test_show_error_leaves_nav_disabled_during_load(self, screen_manager):
+        """A non-load action error must not re-enable arrows while a load runs."""
+        from screens.goals import GoalsScreen
+
+        screen = GoalsScreen(name="goals")
+        screen_manager.add_widget(screen)
+        screen._set_nav_enabled(False)  # a week load is in flight
+
+        screen.show_error("toggle failed")
+
+        assert screen._prev_btn.disabled is True
+        assert screen._next_btn.disabled is True
+
     def test_confirm_add_goal_uses_selected_week(self, screen_manager):
         """confirm_add_goal creates the goal for the currently selected week."""
         from datetime import date
@@ -636,6 +663,36 @@ class TestGoalsScreen:
         mock_create.assert_called_once_with(
             "Plan the week", week_start_date="2026-07-13"
         )
+
+    def test_add_created_goal_skips_if_week_changed(self, screen_manager):
+        """A create that resolves after navigating away isn't rendered on the new week."""
+        from datetime import date
+        from screens.goals import GoalsScreen, GoalCard
+
+        screen = GoalsScreen(name="goals")
+        screen_manager.add_widget(screen)
+        screen._current_week_start = date(2026, 7, 20)  # user has moved to another week
+        before = [w for w in screen.goals_list.children if isinstance(w, GoalCard)]
+
+        # Goal was created for the previously selected week.
+        screen._add_created_goal("Stale goal", 1, "2026-07-13")
+
+        after = [w for w in screen.goals_list.children if isinstance(w, GoalCard)]
+        assert len(after) == len(before)
+
+    def test_add_created_goal_renders_if_week_matches(self, screen_manager):
+        """A create that resolves while its week is still shown renders the card."""
+        from datetime import date
+        from screens.goals import GoalsScreen, GoalCard
+
+        screen = GoalsScreen(name="goals")
+        screen_manager.add_widget(screen)
+        screen._current_week_start = date(2026, 7, 13)
+
+        screen._add_created_goal("Fresh goal", 1, "2026-07-13")
+
+        cards = [w for w in screen.goals_list.children if isinstance(w, GoalCard)]
+        assert any(c.goal_text == "Fresh goal" for c in cards)
 
     def test_change_week_reloads_goals(self, screen_manager):
         """_change_week shifts the week by 7 days and reloads."""

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -714,6 +714,53 @@ class TestGoalsScreen:
 
         assert card.goal_text == "Local edited"
 
+    def test_on_pre_enter_resets_to_current_week(self, screen_manager):
+        """on_pre_enter snaps back to the current week (not a previously browsed one)."""
+        from datetime import date
+        from screens.goals import GoalsScreen
+        from utils.week import monday_of
+
+        screen = GoalsScreen(name="goals")
+        screen_manager.add_widget(screen)
+        screen._current_week_start = date(2000, 1, 3)  # a Monday, long in the past
+
+        with patch.object(screen, "load_goals"):
+            screen.on_pre_enter()
+
+        assert screen._current_week_start == monday_of(date.today())
+
+    def test_populate_goals_ignores_stale_week(self, screen_manager):
+        """A response for a week the user already left is dropped, not rendered."""
+        from screens.goals import GoalsScreen, GoalCard
+
+        screen = GoalsScreen(name="goals")
+        screen_manager.add_widget(screen)
+        screen._add_goal_card("existing", goal_id=1)
+        before = [w for w in screen.goals_list.children if isinstance(w, GoalCard)]
+
+        # week_start_str for a different week than the one currently selected.
+        screen._populate_goals(
+            [{"id": 2, "goal_text": "stale"}], week_start_str="1999-01-04"
+        )
+
+        after = [w for w in screen.goals_list.children if isinstance(w, GoalCard)]
+        assert len(after) == len(before)
+        assert all(c.goal_text != "stale" for c in after)
+
+    def test_load_goals_disables_nav_while_loading(self, screen_manager):
+        """load_goals disables the week arrows until the fetch completes."""
+        from screens.goals import GoalsScreen
+
+        screen = GoalsScreen(name="goals")
+        screen_manager.add_widget(screen)
+
+        with patch("screens.goals.threading.Thread") as mock_thread:
+            mock_thread.return_value = MagicMock()
+            screen.load_goals()
+
+        assert screen._prev_btn.disabled is True
+        assert screen._next_btn.disabled is True
+
 
 class TestJournalScreen:
     """Tests for JournalScreen"""

--- a/utils/week.py
+++ b/utils/week.py
@@ -1,0 +1,21 @@
+"""Week helpers shared across screens and the API client.
+
+Goals and analyses are keyed by ``week_start_date``, which must always be the
+Monday of the week. These helpers keep that math (and its display formatting) in
+one place instead of being re-derived per screen.
+"""
+
+from datetime import date, timedelta
+
+
+def monday_of(d: date) -> date:
+    """Return the Monday of the week containing ``d``."""
+    return d - timedelta(days=d.weekday())
+
+
+def week_range_text(monday: date) -> str:
+    """Human-readable Mon–Sun range, e.g. 'Jul 14 – Jul 20, 2026'."""
+    end = monday + timedelta(days=6)
+    s = monday.strftime('%b %d').replace(' 0', ' ')
+    e = end.strftime('%b %d, %Y').replace(' 0', ' ')
+    return f"{s} – {e}"


### PR DESCRIPTION
## Summary
Makes goals **per-week** in the mobile app and adds **goal editing**. The Django backend already stored each goal against a `week_start_date` (Monday) and supported editing goal text — this PR wires the mobile UI up to those
capabilities, so **no backend changes are required**.

## Edit any goal
- `GoalCard` gains a pencil button next to the trash icon. Tapping it opens a   dialog pre-filled with the goal's text; saving PATCHes `goal_text` via  `update_goal` and updates the card in place.
- Add and edit now share one dialog builder (`_open_goal_dialog`).
- Tapping the edit/delete buttons no longer accidentally toggles the checkbox.

## Per-week goals with history
- New **week navigator** (◀ / ▶ + week-range label) on the Goals screen,  mirroring the Analysis screen.
- `api_client.get_goals(week_start_date)` now sends the `?week_start_date=` filter, so each week shows only its own goals — you can browse past and future weeks.
- New goals are created for the **selected** week, not always the current one (`create_goal(..., week_start_date=...)`).
- Past weeks are fully editable (add / edit / toggle / delete).

## Home stat fix
- "Goals this week" was counting *all* goals across every week; it now counts only the current week by passing the week filter to `get_goals`.

## Backend connectivity (added)
- `API_BASE_URL` is now configurable via the `COACH_API_URL` env var, defaulting to the backend's mDNS name **`http://coach-backend.local:8000/api`**.
- This lets any device on the same LAN reach the backend with **zero per-machine config and no IP hardcoded in the repo** — the `.local` name resolves via Bonjour/Avahi to whatever IP the server currently has.
- Server side: the backend runs with `runserver 0.0.0.0:8000`, `coach-backend.local` is in `ALLOWED_HOSTS`, and an `avahi-publish` systemd service advertises the name on the network.
- Updated `tests/test_buildozer.py` to parse the `os.getenv(...)` default.

## Tests
- `tests/test_api_client.py`: week filter on `get_goals`, `get_goals()` without a week sends no filter, week-specific `create_goal`.
- `tests/test_screens.py`: week navigation reloads, edit persists new text, unchanged-text is a no-op, local (unsaved) card edits without an API call.  Updated two existing tests for the renamed `_goal_field`.
- **167 passed**, ruff clean.

## Notes
- Because the Analysis screen already navigates by week, generating an analysis  for a past week now lines up naturally with that week's goals.
- Not verified in a live GUI here (no display); screens are exercised headlessly by the test fixtures.